### PR TITLE
feat: Add OpenTelemetry monitoring and telemetry infrastructure

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,55 @@
+# C#/.NET ignore patterns for Docker
+bin/
+obj/
+packages/
+*.user
+*.suo
+.vs/
+.vscode/
+.idea/
+
+# Git
+.git/
+.gitignore
+.gitattributes
+
+# Build and test artifacts
+TestResults/
+*.trx
+coverage/
+*.coverage
+artifacts/
+
+# Environment and secrets
+.env*
+*.pfx
+*.key
+*.crt
+secrets/
+
+# OS generated files
+.DS_Store
+Thumbs.db
+*.tmp
+*.swp
+
+# Logs
+*.log
+logs/
+
+# Documentation and examples (exclude from builds)
+*.md
+docs/
+examples/
+release_note/
+images/
+
+# Development tools
+.codegpt
+.specify/
+specs/
+
+# Docker
+Dockerfile*
+.dockerignore
+docker-compose*

--- a/.github/workflows/dotnet_build.yml
+++ b/.github/workflows/dotnet_build.yml
@@ -64,14 +64,29 @@ jobs:
     - name: Create Git Tag
       if: env.NUGET_PUSH_SUCCESS == 'true'
       run: |
-        PACKAGE_FILE=$(ls ./src/nupkg/*.nupkg | head -1)
-        PACKAGE_VERSION=$(echo "$PACKAGE_FILE" | grep -oP '(?<=MessageWorkerPool\.)\d+\.\d+\.\d+(?:\.\d+)?(?:-[a-zA-Z0-9]+)?')
-        if [ -n "$PACKAGE_VERSION" ]; then
-          TAG_NAME="$PACKAGE_VERSION"
-          echo "Creating tag: $TAG_NAME"
-          git tag "$TAG_NAME"
-          git push origin "$TAG_NAME"
-        else
-          echo "Package version could not be determined."
-          exit 1
+        PACKAGE_FILES=$(ls ./src/nupkg/*.nupkg)
+        
+        # Extract versions from both packages
+        MAIN_PACKAGE=$(echo "$PACKAGE_FILES" | grep -E 'MessageWorkerPool\.[0-9]+\.[0-9]+\.[0-9]+' | grep -v 'OpenTelemetry')
+        OTEL_PACKAGE=$(echo "$PACKAGE_FILES" | grep 'MessageWorkerPool.OpenTelemetry')
+        
+        if [ -n "$MAIN_PACKAGE" ]; then
+          MAIN_VERSION=$(echo "$MAIN_PACKAGE" | grep -oP '(?<=MessageWorkerPool\.)\d+\.\d+\.\d+(?:\.\d+)?(?:-[a-zA-Z0-9]+)?')
+          if [ -n "$MAIN_VERSION" ]; then
+            TAG_NAME="$MAIN_VERSION"
+            echo "Creating tag: $TAG_NAME"
+            git tag "$TAG_NAME" || echo "Tag $TAG_NAME already exists"
+            git push origin "$TAG_NAME" || echo "Failed to push tag $TAG_NAME"
+          fi
         fi
+        
+        if [ -n "$OTEL_PACKAGE" ]; then
+          OTEL_VERSION=$(echo "$OTEL_PACKAGE" | grep -oP '(?<=MessageWorkerPool\.OpenTelemetry\.)\d+\.\d+\.\d+(?:\.\d+)?(?:-[a-zA-Z0-9]+)?')
+          if [ -n "$OTEL_VERSION" ]; then
+            TAG_NAME="opentelemetry-$OTEL_VERSION"
+            echo "Creating tag: $TAG_NAME"
+            git tag "$TAG_NAME" || echo "Tag $TAG_NAME already exists"
+            git push origin "$TAG_NAME" || echo "Failed to push tag $TAG_NAME"
+          fi
+        fi
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     hostname: rabbitmq-server
     restart: always
     ports:
-      - "8888:15672"
+      - "15672:15672"
       - "5672:5672"
     healthcheck:
       test: [ "CMD", "rabbitmqctl", "status"]
@@ -110,7 +110,7 @@ services:
     ports:
       - "4317:4317"     # OTLP gRPC receiver
       - "4318:4318"     # OTLP HTTP receiver
-      - "8887:8888"     # Prometheus metrics (avoiding conflict with RabbitMQ)
+      - "8888:8888"     # Prometheus metrics
       - "8889:8889"     # Prometheus exporter metrics
     depends_on:
       - prometheus

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     #stop_grace_period: 120s
     env_file: ./env/.env
     ports:
-      - "9464:9464"
+      - "9464-9474:9464"
     depends_on:
       - publisher
       - otel-collector

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,11 +31,17 @@ services:
   workersample:
     #build: ./examples_worker/python
     #build: ./examples_worker/dotnet
-    build: ./examples_worker/rust
+    build:
+      context: .
+      dockerfile: ./src/Examples/DotNetWorker/Dockerfile
+    #build: ./examples_worker/rust
     #stop_grace_period: 120s
     env_file: ./env/.env
+    ports:
+      - "9464:9464"
     depends_on:
       - publisher
+      - otel-collector
     networks:
       - net-mq
   sqlserver:
@@ -64,9 +70,60 @@ services:
       - net-mq
     depends_on:
       - sqlserver
+
+  # OpenTelemetry Monitoring Stack
+  prometheus:
+    image: prom/prometheus:latest
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/etc/prometheus/console_libraries'
+      - '--web.console.templates=/etc/prometheus/consoles'
+      - '--storage.tsdb.retention.time=200h'
+      - '--web.enable-lifecycle'
+    networks:
+      - net-mq
+    restart: unless-stopped
+
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    ports:
+      - "16686:16686"   # Jaeger UI
+      - "14268:14268"   # HTTP collector
+      - "14250:14250"   # gRPC collector
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+    networks:
+      - net-mq
+    restart: unless-stopped
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:latest
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./monitoring/otel-collector-config.yaml:/etc/otel-collector-config.yaml
+    ports:
+      - "4317:4317"     # OTLP gRPC receiver
+      - "4318:4318"     # OTLP HTTP receiver
+      - "8887:8888"     # Prometheus metrics (avoiding conflict with RabbitMQ)
+      - "8889:8889"     # Prometheus exporter metrics
+    depends_on:
+      - prometheus
+      - jaeger
+    networks:
+      - net-mq
+    restart: unless-stopped
 networks:
   net-mq:
     driver: bridge
+
+volumes:
+  prometheus_data:
 
 
 

--- a/env/.env
+++ b/env/.env
@@ -4,8 +4,9 @@ RABBITMQ_PORT=5672
 
 # OpenTelemetry Configuration
 OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
+OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 OTEL_SERVICE_NAME=MessageWorkerPool
 OTEL_SERVICE_VERSION=1.0.0
 OTEL_RESOURCE_ATTRIBUTES=service.namespace=messageworkerpool,deployment.environment=docker-compose
-PROMETHEUS_ENDPOINT=http://otel-collector:8887/metrics
+PROMETHEUS_ENDPOINT=http://otel-collector:8888/metrics
 JAEGER_ENDPOINT=http://jaeger:14268/api/traces

--- a/env/.env
+++ b/env/.env
@@ -1,3 +1,11 @@
 RABBITMQ_HOSTNAME=rabbitmq-server
 QUEUENAME=worker-queue
 RABBITMQ_PORT=5672
+
+# OpenTelemetry Configuration
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
+OTEL_SERVICE_NAME=MessageWorkerPool
+OTEL_SERVICE_VERSION=1.0.0
+OTEL_RESOURCE_ATTRIBUTES=service.namespace=messageworkerpool,deployment.environment=docker-compose
+PROMETHEUS_ENDPOINT=http://otel-collector:8887/metrics
+JAEGER_ENDPOINT=http://jaeger:14268/api/traces

--- a/env/.local_env
+++ b/env/.local_env
@@ -1,1 +1,9 @@
 RABBITMQ_HOSTNAME=127.0.0.1
+
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
+OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+OTEL_SERVICE_NAME=MessageWorkerPool
+OTEL_SERVICE_VERSION=1.0.0
+OTEL_RESOURCE_ATTRIBUTES=service.namespace=messageworkerpool,deployment.environment=docker-compose
+PROMETHEUS_ENDPOINT=http://otel-collector:8888/metrics
+JAEGER_ENDPOINT=http://jaeger:14268/api/traces

--- a/monitoring/otel-collector-config.yaml
+++ b/monitoring/otel-collector-config.yaml
@@ -1,0 +1,67 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    timeout: 1s
+    send_batch_size: 50
+
+  # Add resource attributes
+  resource:
+    attributes:
+      - key: service.namespace
+        value: messageworkerpool
+        action: upsert
+      - key: deployment.environment
+        value: docker-compose
+        action: upsert
+
+  memory_limiter:
+    limit_mib: 256
+    check_interval: 1s
+
+exporters:
+  # Prometheus exporter
+  prometheus:
+    endpoint: "0.0.0.0:8889"
+
+  # OTLP exporter for Jaeger traces
+  otlp/jaeger:
+    endpoint: jaeger:4317
+    tls:
+      insecure: true
+
+  # Debug exporter for debugging (replaces deprecated logging exporter)
+  debug:
+    verbosity: normal
+
+service:
+  telemetry:
+    logs:
+      level: info
+
+  pipelines:
+    # Metrics pipeline
+    metrics:
+      receivers: [otlp]
+      processors: [memory_limiter, resource, batch]
+      exporters: [prometheus, debug]
+
+    # Traces pipeline
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, resource, batch]
+      exporters: [otlp/jaeger, debug]
+
+    # Logs pipeline
+    logs:
+      receivers: [otlp]
+      processors: [memory_limiter, resource, batch]
+      exporters: [debug]
+
+  extensions: []

--- a/monitoring/otel-collector-config.yaml
+++ b/monitoring/otel-collector-config.yaml
@@ -21,10 +21,6 @@ processors:
         value: docker-compose
         action: upsert
 
-  memory_limiter:
-    limit_mib: 256
-    check_interval: 1s
-
 exporters:
   # Prometheus exporter
   prometheus:
@@ -49,19 +45,17 @@ service:
     # Metrics pipeline
     metrics:
       receivers: [otlp]
-      processors: [memory_limiter, resource, batch]
+      processors: [resource, batch]
       exporters: [prometheus, debug]
 
     # Traces pipeline
     traces:
       receivers: [otlp]
-      processors: [memory_limiter, resource, batch]
+      processors: [resource, batch]
       exporters: [otlp/jaeger, debug]
 
     # Logs pipeline
     logs:
       receivers: [otlp]
-      processors: [memory_limiter, resource, batch]
+      processors: [resource, batch]
       exporters: [debug]
-
-  extensions: []

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -3,8 +3,6 @@ global:
   evaluation_interval: 15s
 
 rule_files:
-  # - "first_rules.yml"
-  # - "second_rules.yml"
 
 scrape_configs:
   # OpenTelemetry Collector metrics
@@ -14,15 +12,30 @@ scrape_configs:
     scrape_interval: 10s
     metrics_path: /metrics
 
-  # MessageWorkerPool application metrics
+  # MessageWorkerPool application metrics - Multi-worker support
+  # Docker Compose creates network aliases that resolve to all container IPs
   - job_name: 'messageworkerpool'
-    static_configs:
-      - targets: ['workersample:9464']
+    dns_sd_configs:
+      - names:
+          - 'workersample'
+        type: 'A'
+        port: 9464
+        refresh_interval: 15s
     scrape_interval: 10s
     metrics_path: /metrics
     honor_timestamps: false
     scrape_protocols:
       - PrometheusText0.0.4
+    # Relabel to add instance information
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __tmp_address
+      - source_labels: [__tmp_address]
+        regex: '(.+):.*'
+        target_label: container_ip
+        replacement: '$1'
+      - source_labels: [__address__]
+        target_label: instance
 
   # Prometheus self-monitoring
   - job_name: 'prometheus'

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,37 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+rule_files:
+  # - "first_rules.yml"
+  # - "second_rules.yml"
+
+scrape_configs:
+  # OpenTelemetry Collector metrics
+  - job_name: 'otel-collector'
+    static_configs:
+      - targets: ['otel-collector:8889']
+    scrape_interval: 10s
+    metrics_path: /metrics
+
+  # MessageWorkerPool application metrics
+  - job_name: 'messageworkerpool'
+    static_configs:
+      - targets: ['workersample:9464']
+    scrape_interval: 10s
+    metrics_path: /metrics
+    honor_timestamps: false
+    scrape_protocols:
+      - PrometheusText0.0.4
+
+  # Prometheus self-monitoring
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+  # RabbitMQ metrics (if enabled)
+  - job_name: 'rabbitmq'
+    static_configs:
+      - targets: ['myrabbitmq:15692']
+    scrape_interval: 30s
+    metrics_path: /metrics

--- a/src/Examples/DotNetWorker/Dockerfile
+++ b/src/Examples/DotNetWorker/Dockerfile
@@ -1,0 +1,16 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0 as build
+COPY ./ /sourceCode
+WORKDIR /sourceCode
+RUN dotnet restore src/MessageWorkerPool.sln
+RUN dotnet publish src/Examples/DotNetWorker/WorkerHost/WorkerHost.csproj -c Release -o /app/host
+RUN dotnet publish src/Examples/DotNetWorker/WorkerClient/WorkerClient.csproj -c Release -o /app/WorkerClient
+
+# WorkerPool runtime
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 as server
+WORKDIR /app
+COPY --from=build /app .
+
+# Expose metrics port for Prometheus
+EXPOSE 9464
+
+CMD ["dotnet","host/WorkerHost.dll"]

--- a/src/Examples/DotNetWorker/README.md
+++ b/src/Examples/DotNetWorker/README.md
@@ -1,0 +1,53 @@
+# .NET Worker Example
+
+This example demonstrates how to use the MessageWorkerPool library with direct project references instead of NuGet package references.
+
+## Structure
+
+- **WorkerHost**: The main application that sets up and manages the worker pool
+- **WorkerClient**: The worker process that handles individual tasks
+
+## Building and Running
+
+### Local Development
+
+1. Build the solution:
+   ```powershell
+   cd src
+   dotnet build
+   ```
+
+2. Run the WorkerHost:
+   ```powershell
+   cd src/Examples/DotNetWorker/WorkerHost
+   dotnet run
+   ```
+
+### Docker
+
+1. Build the Docker image:
+   ```powershell
+   cd src/Examples/DotNetWorker
+   docker build -t messageworkerpool-example .
+   ```
+
+2. Run with Docker Compose (if you have RabbitMQ setup):
+   ```powershell
+   docker run --network host messageworkerpool-example
+   ```
+
+## Configuration
+
+The worker pool can be configured via environment variables:
+
+- `USERNAME`: RabbitMQ username (default: guest)
+- `PASSWORD`: RabbitMQ password (default: guest)
+- `RABBITMQ_HOSTNAME`: RabbitMQ hostname (default: localhost)
+- `RABBITMQ_PORT`: RabbitMQ port (default: 5672)
+- `QUEUENAME`: Queue name to process (default: worker-queue)
+
+## Key Differences from examples_worker/dotnet
+
+1. **Direct Project References**: Uses `<ProjectReference>` instead of `<PackageReference>` for MessageWorkerPool
+2. **Simplified Build**: The Dockerfile can build directly without needing pre-built binaries
+3. **Same Folder Structure**: Maintains clean separation between host and client projects

--- a/src/Examples/DotNetWorker/WorkerClient/JsonExtension.cs
+++ b/src/Examples/DotNetWorker/WorkerClient/JsonExtension.cs
@@ -1,0 +1,28 @@
+using System;
+using Newtonsoft.Json;
+using MessageWorkerPool.Utilities;
+
+namespace WorkerClient
+{
+    public static class JsonExtension
+    {
+        public static string ToIgnoreMessage(this string message) 
+        {
+            return JsonConvert.SerializeObject(new MessageOutputTask()
+            {
+                Message = message,
+                Status = MessageStatus.IGNORE_MESSAGE
+            });
+        }
+
+        public static string ToJson(this object obj)
+        {
+            return JsonConvert.SerializeObject(obj);
+        }
+
+        public static T ToObject<T>(this string json)
+        {
+            return JsonConvert.DeserializeObject<T>(json);
+        }
+    }
+}

--- a/src/Examples/DotNetWorker/WorkerClient/MessageProcessor.cs
+++ b/src/Examples/DotNetWorker/WorkerClient/MessageProcessor.cs
@@ -1,0 +1,100 @@
+using System;
+using MessageWorkerPool.IO;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Threading;
+using MessageWorkerPool.Utilities;
+
+namespace WorkerClient
+{
+    public class MessageProcessor
+    {
+        Task _task;
+        PipeStreamWrapper _pipeStream;
+        CancellationTokenSource closeToken = new CancellationTokenSource();
+        volatile int isClose = 0;
+
+        public async Task InitialAsync()
+        {
+            var pipeName = Console.ReadLine();
+            var clientPipe = await PipeClientFactory.CreateAndConnectPipeAsync(pipeName).ConfigureAwait(false);
+            _pipeStream = new PipeStreamWrapper(clientPipe);
+            _task = Task.Run(async () => {
+                Console.WriteLine("in Task.Run...");
+                string line;
+                while ((line = Console.ReadLine()) != null)
+                {
+                    if (line == MessageCommunicate.CLOSED_SIGNAL)
+                    {
+                        closeToken.Cancel();
+                        break;
+                    }
+                }
+                Interlocked.Exchange(ref isClose, 1);
+            });
+        }
+
+        public async Task DoWorkAsync(Func<MessageInputTask, CancellationToken, Task<MessageOutputTask>> process)
+        {
+            Console.WriteLine("worker starting...");
+            Console.WriteLine("Enter text 'quit' to stop:");
+            while (Interlocked.CompareExchange(ref isClose, 1, 1) == 0)
+            {
+                try
+                {
+                    var task = await _pipeStream.ReadAsync<MessageInputTask>().ConfigureAwait(false);
+                    if (task == null)
+                    {
+                        //todo handle...
+                    }
+                    else
+                    {
+                        int timeoutMilliseconds = ParseTimeout(task.Headers);
+                        var res = await process(task, CreateMessageCancellationToken(timeoutMilliseconds)).ConfigureAwait(false);
+                        await _pipeStream.WriteAsync(res).ConfigureAwait(false);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"Worker occur unexpected error: {ex.ToString()}");
+
+                    await _pipeStream.WriteAsync(new MessageOutputTask()
+                    {
+                        Message = ex.Message,
+                        Status = MessageStatus.MESSAGE_DONE
+                    }.ToJson()).ConfigureAwait(false);
+                }
+            }
+            _pipeStream.Dispose();
+            Console.WriteLine("loop exits!:");
+            await _task;
+        }
+
+        int ParseTimeout(IDictionary<string, string> headers)
+        {
+            if (headers != null &&
+                headers.TryGetValue("TimeoutMilliseconds", out var str) &&
+                int.TryParse(str, out var timeout))
+            {
+                return timeout;
+            }
+            return -1;
+        }
+
+        private CancellationToken CreateMessageCancellationToken(int timeoutMilliseconds)
+        {
+            CancellationTokenSource cts = new CancellationTokenSource();
+            cts.CancelAfter(timeoutMilliseconds < 0 ? Timeout.InfiniteTimeSpan : TimeSpan.FromMilliseconds(timeoutMilliseconds));
+            var tokens = CancellationTokenSource.CreateLinkedTokenSource(cts.Token, closeToken.Token);
+            return tokens.Token;
+        }
+
+        public void DoWork(Func<MessageInputTask, CancellationToken, MessageOutputTask> process)
+        {
+            Func<MessageInputTask, CancellationToken, Task<MessageOutputTask>> asyncProcess = (task, cancelToken) =>
+                Task.FromResult(process(task, cancelToken));
+
+            DoWorkAsync(asyncProcess).GetAwaiter().GetResult();
+        }
+    }
+}

--- a/src/Examples/DotNetWorker/WorkerClient/PipeClientFactory.cs
+++ b/src/Examples/DotNetWorker/WorkerClient/PipeClientFactory.cs
@@ -1,0 +1,15 @@
+using System.Threading.Tasks;
+using System.IO.Pipes;
+
+namespace WorkerClient
+{
+    public static class PipeClientFactory
+    {
+        public static async Task<NamedPipeClientStream> CreateAndConnectPipeAsync(string pipeName)
+        {
+            var client = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut);
+            await client.ConnectAsync().ConfigureAwait(false);
+            return client;
+        }
+    }
+}

--- a/src/Examples/DotNetWorker/WorkerClient/Program.cs
+++ b/src/Examples/DotNetWorker/WorkerClient/Program.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MessageWorkerPool.Utilities;
+using MessageWorkerPool.Telemetry;
+using MessageWorkerPool.OpenTelemetry.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Trace;
+
+namespace WorkerClient
+{
+    class Program
+    {
+        static async Task Main(string[] args)
+        {
+            // Initialize OpenTelemetry for the worker client using the new extension
+            var serviceCollection = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+            serviceCollection.AddMessageWorkerPoolOpenTelemetry("MessageWorkerPool.Example.Client", "1.0.0");
+            
+            // Configure OpenTelemetry manually for this simple client
+            serviceCollection.AddOpenTelemetry()
+                .WithTracing(tracing =>
+                {
+                    tracing.AddMessageWorkerPoolInstrumentation("MessageWorkerPool.Example.Client")
+                           .AddOtlpExporter(options =>
+                           {
+                               options.Endpoint = new Uri(Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT") ?? "http://localhost:4317");
+                           });
+                });
+
+            using var serviceProvider = serviceCollection.BuildServiceProvider();
+
+            MessageProcessor processor = new MessageProcessor();
+            await processor.InitialAsync();
+            processor.DoWork((task, token) => {
+                using var activity = TelemetryManager.StartTaskProcessingActivity("worker-client", "default", task.CorrelationId);
+                activity?.SetTag("message.content", task.Message);
+                activity?.SetTag("worker.client", "example");
+                
+                Console.WriteLine($"Processing task with message: {task.Message}, Sleeping 1s".ToIgnoreMessage());
+                Thread.Sleep(1000);
+                
+                activity?.SetTag("processing.result", "success");
+                TelemetryManager.SetTaskStatus(activity, MessageStatus.MESSAGE_DONE);
+                return new MessageOutputTask()
+                {
+                    Message = "Processed successfully!",
+                    Status = MessageStatus.MESSAGE_DONE
+                };
+            });
+        }
+    }
+}

--- a/src/Examples/DotNetWorker/WorkerClient/Program.cs
+++ b/src/Examples/DotNetWorker/WorkerClient/Program.cs
@@ -16,30 +16,31 @@ namespace WorkerClient
             // Initialize OpenTelemetry for the worker client using the new extension
             var serviceCollection = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
             serviceCollection.AddMessageWorkerPoolOpenTelemetry("MessageWorkerPool.Example.Client", "1.0.0");
-            
+
             // Configure OpenTelemetry manually for this simple client
             serviceCollection.AddOpenTelemetry()
                 .WithTracing(tracing =>
                 {
                     tracing.AddMessageWorkerPoolInstrumentation("MessageWorkerPool.Example.Client")
-                           .AddOtlpExporter(options =>
-                           {
-                               options.Endpoint = new Uri(Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT") ?? "http://localhost:4317");
-                           });
+                        .AddOtlpExporter(options =>
+                        {
+                            options.Endpoint = new Uri(Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT"));
+                        });
                 });
 
             using var serviceProvider = serviceCollection.BuildServiceProvider();
 
             MessageProcessor processor = new MessageProcessor();
             await processor.InitialAsync();
-            processor.DoWork((task, token) => {
+            await processor.DoWorkAsync(async (task, token) => {
                 using var activity = TelemetryManager.StartTaskProcessingActivity("worker-client", "default", task.CorrelationId);
                 activity?.SetTag("message.content", task.Message);
                 activity?.SetTag("worker.client", "example");
-                
+
                 Console.WriteLine($"Processing task with message: {task.Message}, Sleeping 1s".ToIgnoreMessage());
-                Thread.Sleep(1000);
-                
+
+                await Task.Delay(1000,token).ConfigureAwait(false);
+
                 activity?.SetTag("processing.result", "success");
                 TelemetryManager.SetTaskStatus(activity, MessageStatus.MESSAGE_DONE);
                 return new MessageOutputTask()
@@ -47,7 +48,7 @@ namespace WorkerClient
                     Message = "Processed successfully!",
                     Status = MessageStatus.MESSAGE_DONE
                 };
-            });
+            }).ConfigureAwait(false);
         }
     }
 }

--- a/src/Examples/DotNetWorker/WorkerClient/WorkerClient.csproj
+++ b/src/Examples/DotNetWorker/WorkerClient/WorkerClient.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>false</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\MessageWorkerPool\MessageWorkerPool.csproj" />
+    <ProjectReference Include="..\..\..\MessageWorkerPool.OpenTelemetry\MessageWorkerPool.OpenTelemetry.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MessagePack" Version="3.1.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+
+</Project>

--- a/src/Examples/DotNetWorker/WorkerHost/Program.cs
+++ b/src/Examples/DotNetWorker/WorkerHost/Program.cs
@@ -31,10 +31,14 @@ namespace WorkerHost
             });
 
             // Add MessageWorkerPool telemetry with OpenTelemetry
+            var hostname = Environment.GetEnvironmentVariable("HOSTNAME") ?? System.Net.Dns.GetHostName();
+            var instanceId = Environment.GetEnvironmentVariable("INSTANCE_ID") ?? hostname;
+
             builder.Services.AddMessageWorkerPoolTelemetry(options =>
             {
                 options.ServiceName = "MessageWorkerPool.Example.Host";
                 options.ServiceVersion = "1.0.0";
+                options.ServiceInstanceId = instanceId;  // Add instance identifier
                 options.EnableRuntimeInstrumentation = true;
                 options.EnableProcessInstrumentation = true;
 

--- a/src/Examples/DotNetWorker/WorkerHost/Program.cs
+++ b/src/Examples/DotNetWorker/WorkerHost/Program.cs
@@ -38,7 +38,6 @@ namespace WorkerHost
             {
                 options.ServiceName = "MessageWorkerPool.Example.Host";
                 options.ServiceVersion = "1.0.0";
-                options.ServiceInstanceId = instanceId;  // Add instance identifier
                 options.EnableRuntimeInstrumentation = true;
                 options.EnableProcessInstrumentation = true;
 

--- a/src/Examples/DotNetWorker/WorkerHost/Program.cs
+++ b/src/Examples/DotNetWorker/WorkerHost/Program.cs
@@ -1,0 +1,89 @@
+using Microsoft.Extensions.DependencyInjection;
+using MessageWorkerPool;
+using MessageWorkerPool.RabbitMq;
+using Microsoft.Extensions.Logging;
+using MessageWorkerPool.Extensions;
+using MessageWorkerPool.OpenTelemetry.Extensions;
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Console;
+using Microsoft.AspNetCore.Builder;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace WorkerHost
+{
+    public class Program
+    {
+        public static async Task Main(string[] args)
+        {
+            var builder = WebApplication.CreateBuilder(args);
+
+            // Configure logging
+            builder.Logging.ClearProviders();
+            builder.Logging.AddConsole(options => {
+                options.FormatterName = ConsoleFormatterNames.Simple;
+            });
+            builder.Services.Configure<SimpleConsoleFormatterOptions>(options => {
+                options.IncludeScopes = true;
+                options.TimestampFormat = " yyyy-MM-dd HH:mm:ss ";
+            });
+
+            // Add MessageWorkerPool telemetry with OpenTelemetry
+            builder.Services.AddMessageWorkerPoolTelemetry(options =>
+            {
+                options.ServiceName = "MessageWorkerPool.Example.Host";
+                options.ServiceVersion = "1.0.0";
+                options.EnableRuntimeInstrumentation = true;
+                options.EnableProcessInstrumentation = true;
+
+                // Configure metrics with OTLP exporter and Prometheus
+                options.ConfigureMetrics = metrics =>
+                {
+                    metrics.AddOtlpExporter(otlpOptions =>
+                    {
+                        otlpOptions.Endpoint = new Uri(Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT") ?? "http://localhost:4317");
+                    });
+                    metrics.AddPrometheusExporter(prometheusOptions =>
+                    {
+                        prometheusOptions.DisableTotalNameSuffixForCounters = true;
+                    });
+                };
+
+                // Configure tracing with OTLP exporter
+                options.ConfigureTracing = tracing =>
+                {
+                    tracing.AddOtlpExporter(otlpOptions =>
+                    {
+                        otlpOptions.Endpoint = new Uri(Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT") ?? "http://localhost:4317");
+                    });
+                };
+            });
+
+            // Add RabbitMQ Worker Pool
+            builder.Services.AddRabbitMqWorkerPool(new RabbitMqSetting
+            {
+                UserName = Environment.GetEnvironmentVariable("USERNAME") ?? "guest",
+                Password = Environment.GetEnvironmentVariable("PASSWORD") ?? "guest",
+                HostName = Environment.GetEnvironmentVariable("RABBITMQ_HOSTNAME") ?? "localhost",
+                Port = ushort.TryParse(Environment.GetEnvironmentVariable("RABBITMQ_PORT"), out ushort p) ? p : (ushort) 5672,
+                PrefetchTaskCount = 3
+            }, new WorkerPoolSetting() {
+                WorkerUnitCount = 5,
+                CommandLine = "dotnet",
+                Arguments = @"./WorkerClient/WorkerClient.dll",
+                QueueName = Environment.GetEnvironmentVariable("QUEUENAME") ?? "worker-queue",
+            });
+
+            var app = builder.Build();
+
+            // Map Prometheus metrics endpoint
+            app.MapPrometheusScrapingEndpoint();
+
+            // Configure URLs for metrics endpoint
+            app.Urls.Add("http://*:9464");
+
+            await app.RunAsync();
+        }
+    }
+}

--- a/src/Examples/DotNetWorker/WorkerHost/WorkerHost.csproj
+++ b/src/Examples/DotNetWorker/WorkerHost/WorkerHost.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<OutputType>Exe</OutputType>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\..\MessageWorkerPool\MessageWorkerPool.csproj" />
+		<ProjectReference Include="..\..\..\MessageWorkerPool.OpenTelemetry\MessageWorkerPool.OpenTelemetry.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+		<PackageReference Include="RabbitMQ.Client" Version="6.8.1" />
+		<PackageReference Include="MessagePack" Version="3.1.1" />
+		<PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.9.0-alpha.2" />
+	</ItemGroup>
+</Project>

--- a/src/Examples/DotNetWorker/WorkerHost/WorkerHost.csproj
+++ b/src/Examples/DotNetWorker/WorkerHost/WorkerHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Worker">
+﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
 		<OutputType>Exe</OutputType>

--- a/src/MessageWorkerPool.OpenTelemetry/Extensions/MessageWorkerPoolOpenTelemetryExtensions.cs
+++ b/src/MessageWorkerPool.OpenTelemetry/Extensions/MessageWorkerPoolOpenTelemetryExtensions.cs
@@ -1,0 +1,151 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using MessageWorkerPool.Telemetry;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+namespace MessageWorkerPool.OpenTelemetry.Extensions
+{
+    /// <summary>
+    /// Extension methods for configuring OpenTelemetry with MessageWorkerPool.
+    /// </summary>
+    public static class MessageWorkerPoolOpenTelemetryExtensions
+    {
+        /// <summary>
+        /// Enables OpenTelemetry telemetry for MessageWorkerPool.
+        /// </summary>
+        /// <param name="services">The service collection.</param>
+        /// <param name="serviceName">The service name for telemetry.</param>
+        /// <param name="serviceVersion">The service version for telemetry.</param>
+        /// <returns>The service collection for chaining.</returns>
+        public static IServiceCollection AddMessageWorkerPoolOpenTelemetry(
+            this IServiceCollection services,
+            string serviceName = "MessageWorkerPool",
+            string serviceVersion = "1.0.0")
+        {
+            // Set the OpenTelemetry provider
+            var provider = new OpenTelemetryProvider(serviceName, serviceVersion);
+            TelemetryManager.SetProvider(provider);
+
+            // Set the trace context extractor for W3C trace context propagation
+            TelemetryManager.SetTraceContextExtractor(TraceContextPropagation.ExtractTraceContext);
+
+            return services;
+        }
+
+        /// <summary>
+        /// Adds MessageWorkerPool metrics to the OpenTelemetry MeterProvider.
+        /// </summary>
+        /// <param name="builder">The MeterProviderBuilder instance.</param>
+        /// <param name="serviceName">The service name for metrics (default: MessageWorkerPool).</param>
+        /// <returns>The MeterProviderBuilder for chaining.</returns>
+        public static MeterProviderBuilder AddMessageWorkerPoolInstrumentation(
+            this MeterProviderBuilder builder,
+            string serviceName = "MessageWorkerPool")
+        {
+            if (builder == null)
+                throw new ArgumentNullException(nameof(builder));
+
+            return builder.AddMeter(serviceName);
+        }
+
+        /// <summary>
+        /// Adds MessageWorkerPool tracing to the OpenTelemetry TracerProvider.
+        /// </summary>
+        /// <param name="builder">The TracerProviderBuilder instance.</param>
+        /// <param name="serviceName">The service name for tracing (default: MessageWorkerPool).</param>
+        /// <returns>The TracerProviderBuilder for chaining.</returns>
+        public static TracerProviderBuilder AddMessageWorkerPoolInstrumentation(
+            this TracerProviderBuilder builder,
+            string serviceName = "MessageWorkerPool")
+        {
+            if (builder == null)
+                throw new ArgumentNullException(nameof(builder));
+
+            return builder.AddSource(serviceName);
+        }
+
+        /// <summary>
+        /// Configures OpenTelemetry with all MessageWorkerPool instrumentation and common settings.
+        /// </summary>
+        /// <param name="services">The service collection.</param>
+        /// <param name="configure">Optional configuration action.</param>
+        /// <returns>The service collection for chaining.</returns>
+        public static IServiceCollection AddMessageWorkerPoolTelemetry(
+            this IServiceCollection services,
+            Action<MessageWorkerPoolTelemetryOptions> configure = null)
+        {
+            var options = new MessageWorkerPoolTelemetryOptions();
+            configure?.Invoke(options);
+
+            // Set the OpenTelemetry provider
+            var provider = new OpenTelemetryProvider(options.ServiceName, options.ServiceVersion);
+            TelemetryManager.SetProvider(provider);
+
+            // Set the trace context extractor for W3C trace context propagation
+            TelemetryManager.SetTraceContextExtractor(TraceContextPropagation.ExtractTraceContext);
+
+            // Configure OpenTelemetry
+            services.AddOpenTelemetry()
+                .ConfigureResource(resource => resource
+                    .AddService(options.ServiceName, options.ServiceVersion))
+                .WithMetrics(metrics =>
+                {
+                    metrics.AddMessageWorkerPoolInstrumentation(options.ServiceName);
+
+                    if (options.EnableRuntimeInstrumentation)
+                        metrics.AddRuntimeInstrumentation();
+
+                    if (options.EnableProcessInstrumentation)
+                        metrics.AddProcessInstrumentation();
+
+                    options.ConfigureMetrics?.Invoke(metrics);
+                })
+                .WithTracing(tracing =>
+                {
+                    tracing.AddMessageWorkerPoolInstrumentation(options.ServiceName);
+                    options.ConfigureTracing?.Invoke(tracing);
+                });
+
+            return services;
+        }
+    }
+
+    /// <summary>
+    /// Configuration options for MessageWorkerPool telemetry.
+    /// </summary>
+    public class MessageWorkerPoolTelemetryOptions
+    {
+        /// <summary>
+        /// Gets or sets the service name for telemetry.
+        /// </summary>
+        public string ServiceName { get; set; } = "MessageWorkerPool";
+
+        /// <summary>
+        /// Gets or sets the service version for telemetry.
+        /// </summary>
+        public string ServiceVersion { get; set; } = "1.0.0";
+
+        /// <summary>
+        /// Gets or sets whether to enable runtime instrumentation.
+        /// </summary>
+        public bool EnableRuntimeInstrumentation { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets whether to enable process instrumentation.
+        /// </summary>
+        public bool EnableProcessInstrumentation { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets an action to configure metrics.
+        /// </summary>
+        public Action<MeterProviderBuilder> ConfigureMetrics { get; set; }
+
+        /// <summary>
+        /// Gets or sets an action to configure tracing.
+        /// </summary>
+        public Action<TracerProviderBuilder> ConfigureTracing { get; set; }
+    }
+}

--- a/src/MessageWorkerPool.OpenTelemetry/MessageWorkerPool.OpenTelemetry.csproj
+++ b/src/MessageWorkerPool.OpenTelemetry/MessageWorkerPool.OpenTelemetry.csproj
@@ -2,14 +2,17 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <OutputType>Library</OutputType>
     <PackageId>MessageWorkerPool.OpenTelemetry</PackageId>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Authors>Daniel_Shih</Authors>
     <PackageTags>C#,multiple-processes,Messaging,OpenTelemetry,Telemetry</PackageTags>
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://github.com/isdaniel/MessageWorkerPool</PackageProjectUrl>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <PackageDescription>OpenTelemetry extensions for MessageWorkerPool providing metrics and tracing capabilities.</PackageDescription>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Nullable>disable</Nullable>
   </PropertyGroup>
@@ -25,6 +28,10 @@
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.1"/>
     <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.12.0-beta.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/MessageWorkerPool.OpenTelemetry/MessageWorkerPool.OpenTelemetry.csproj
+++ b/src/MessageWorkerPool.OpenTelemetry/MessageWorkerPool.OpenTelemetry.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <PackageId>MessageWorkerPool.OpenTelemetry</PackageId>
+    <Authors>Daniel_Shih</Authors>
+    <PackageTags>C#,multiple-processes,Messaging,OpenTelemetry,Telemetry</PackageTags>
+    <RepositoryType>git</RepositoryType>
+    <PackageProjectUrl>https://github.com/isdaniel/MessageWorkerPool</PackageProjectUrl>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <Version>0.1.0</Version>
+    <PackageDescription>OpenTelemetry extensions for MessageWorkerPool providing metrics and tracing capabilities.</PackageDescription>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MessageWorkerPool\MessageWorkerPool.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.HttpListener" Version="1.8.0-rc.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.1"/>
+    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.12.0-beta.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/MessageWorkerPool.OpenTelemetry/OpenTelemetryActivity.cs
+++ b/src/MessageWorkerPool.OpenTelemetry/OpenTelemetryActivity.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using MessageWorkerPool.Telemetry.Abstractions;
+
+namespace MessageWorkerPool.OpenTelemetry
+{
+    /// <summary>
+    /// OpenTelemetry implementation of IActivity.
+    /// </summary>
+    public class OpenTelemetryActivity : IActivity
+    {
+        private readonly Activity _activity;
+        private bool _disposed = false;
+
+        /// <summary>
+        /// Initializes a new instance of OpenTelemetryActivity.
+        /// </summary>
+        /// <param name="activity">The underlying OpenTelemetry Activity.</param>
+        public OpenTelemetryActivity(Activity activity)
+        {
+            _activity = activity ?? throw new ArgumentNullException(nameof(activity));
+        }
+
+        /// <inheritdoc />
+        public void SetTag(string key, object value)
+        {
+            if (_disposed || string.IsNullOrEmpty(key))
+                return;
+
+            _activity.SetTag(key, value?.ToString());
+        }
+
+        /// <inheritdoc />
+        public void SetTags(IDictionary<string, object> tags)
+        {
+            if (_disposed || tags == null)
+                return;
+
+            foreach (var tag in tags)
+            {
+                SetTag(tag.Key, tag.Value);
+            }
+        }
+
+        /// <inheritdoc />
+        public void SetStatus(ActivityStatus status, string description = null)
+        {
+            if (_disposed)
+                return;
+
+            var otelStatus = status == ActivityStatus.Ok ? ActivityStatusCode.Ok : 
+                           status == ActivityStatus.Error ? ActivityStatusCode.Error : 
+                           ActivityStatusCode.Unset;
+
+            _activity.SetStatus(otelStatus, description);
+        }
+
+        /// <inheritdoc />
+        public void RecordException(Exception exception)
+        {
+            if (_disposed || exception == null)
+                return;
+
+            // Record exception details as tags (RecordException not available in .NET Standard 2.0)
+            SetTag("exception.type", exception.GetType().FullName);
+            SetTag("exception.message", exception.Message);
+            SetTag("exception.stacktrace", exception.StackTrace);
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                _activity?.Dispose();
+                _disposed = true;
+            }
+        }
+    }
+}

--- a/src/MessageWorkerPool.OpenTelemetry/OpenTelemetryActivity.cs
+++ b/src/MessageWorkerPool.OpenTelemetry/OpenTelemetryActivity.cs
@@ -49,8 +49,8 @@ namespace MessageWorkerPool.OpenTelemetry
             if (_disposed)
                 return;
 
-            var otelStatus = status == ActivityStatus.Ok ? ActivityStatusCode.Ok : 
-                           status == ActivityStatus.Error ? ActivityStatusCode.Error : 
+            var otelStatus = status == ActivityStatus.Ok ? ActivityStatusCode.Ok :
+                           status == ActivityStatus.Error ? ActivityStatusCode.Error :
                            ActivityStatusCode.Unset;
 
             _activity.SetStatus(otelStatus, description);
@@ -62,7 +62,6 @@ namespace MessageWorkerPool.OpenTelemetry
             if (_disposed || exception == null)
                 return;
 
-            // Record exception details as tags (RecordException not available in .NET Standard 2.0)
             SetTag("exception.type", exception.GetType().FullName);
             SetTag("exception.message", exception.Message);
             SetTag("exception.stacktrace", exception.StackTrace);

--- a/src/MessageWorkerPool.OpenTelemetry/OpenTelemetryMetrics.cs
+++ b/src/MessageWorkerPool.OpenTelemetry/OpenTelemetryMetrics.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using MessageWorkerPool.Telemetry.Abstractions;
+
+namespace MessageWorkerPool.OpenTelemetry
+{
+    /// <summary>
+    /// OpenTelemetry implementation of IMetrics for WorkerPool operations.
+    /// Tracks worker health, task processing, and performance metrics.
+    /// </summary>
+    public class OpenTelemetryMetrics : IMetrics, IDisposable
+    {
+        private readonly Meter _meter;
+        private bool _disposed = false;
+
+        // Counters
+        private readonly Counter<long> _tasksProcessedCounter;
+        private readonly Counter<long> _tasksFailedCounter;
+        private readonly Counter<long> _tasksRejectedCounter;
+
+        // Gauges (using ObservableGauge)
+        private readonly ObservableGauge<int> _activeWorkersGauge;
+        private readonly ObservableGauge<int> _processingTasksGauge;
+        private readonly ObservableGauge<int> _healthyWorkersGauge;
+        private readonly ObservableGauge<int> _stoppedWorkersGauge;
+
+        // Histogram for task processing duration
+        private readonly Histogram<double> _taskProcessingDuration;
+
+        // State tracking
+        private int _activeWorkers;
+        private int _processingTasks;
+        private int _healthyWorkers;
+        private int _stoppedWorkers;
+
+        /// <summary>
+        /// Initializes a new instance of OpenTelemetryMetrics.
+        /// </summary>
+        /// <param name="meterName">The name of the meter (default: MessageWorkerPool).</param>
+        /// <param name="version">The version of the instrumentation (default: 1.0.0).</param>
+        public OpenTelemetryMetrics(string meterName = "MessageWorkerPool", string version = "1.0.0")
+        {
+            _meter = new Meter(meterName, version);
+
+            // Initialize counters
+            _tasksProcessedCounter = _meter.CreateCounter<long>(
+                "worker_processed_tasks_total",
+                description: "Total number of tasks successfully processed by workers");
+
+            _tasksFailedCounter = _meter.CreateCounter<long>(
+                "worker_failed_tasks_total",
+                description: "Total number of tasks that failed during processing");
+
+            _tasksRejectedCounter = _meter.CreateCounter<long>(
+                "worker_rejected_tasks_total",
+                description: "Total number of tasks rejected by workers");
+
+            // Initialize observable gauges
+            _activeWorkersGauge = _meter.CreateObservableGauge<int>(
+                "workerpool_active_workers",
+                () => _activeWorkers,
+                description: "Number of active workers in the pool");
+
+            _processingTasksGauge = _meter.CreateObservableGauge<int>(
+                "workerpool_processing_tasks",
+                () => _processingTasks,
+                description: "Number of tasks currently being processed");
+
+            _healthyWorkersGauge = _meter.CreateObservableGauge<int>(
+                "workerpool_healthy_workers",
+                () => _healthyWorkers,
+                description: "Number of healthy (running) workers");
+
+            _stoppedWorkersGauge = _meter.CreateObservableGauge<int>(
+                "workerpool_stopped_workers",
+                () => _stoppedWorkers,
+                description: "Number of stopped workers");
+
+            // Initialize histogram
+            _taskProcessingDuration = _meter.CreateHistogram<double>(
+                "worker_task_duration_seconds",
+                unit: "s",
+                description: "Duration of task processing in seconds");
+        }
+
+        /// <inheritdoc />
+        public void RecordTaskProcessed(string queueName = null, string workerId = null)
+        {
+            _tasksProcessedCounter.Add(1, CreateTags(queueName, workerId));
+        }
+
+        /// <inheritdoc />
+        public void RecordTaskFailed(string queueName = null, string workerId = null, string errorType = null)
+        {
+            var tags = CreateTags(queueName, workerId);
+            if (!string.IsNullOrEmpty(errorType))
+            {
+                tags = new KeyValuePair<string, object>[]
+                {
+                    tags[0], tags[1],
+                    new KeyValuePair<string, object>("error.type", errorType)
+                };
+            }
+            _tasksFailedCounter.Add(1, tags);
+        }
+
+        /// <inheritdoc />
+        public void RecordTaskRejected(string queueName = null, string workerId = null)
+        {
+            _tasksRejectedCounter.Add(1, CreateTags(queueName, workerId));
+        }
+
+        /// <inheritdoc />
+        public void RecordTaskDuration(double durationMs, string queueName = null, string workerId = null)
+        {
+            // Convert milliseconds to seconds for Prometheus consistency
+            _taskProcessingDuration.Record(durationMs / 1000.0, CreateTags(queueName, workerId));
+        }
+
+        /// <inheritdoc />
+        public void SetActiveWorkers(int count)
+        {
+            _activeWorkers = count;
+        }
+
+        /// <inheritdoc />
+        public void SetProcessingTasks(int count)
+        {
+            _processingTasks = count;
+        }
+
+        /// <inheritdoc />
+        public void SetHealthyWorkers(int count)
+        {
+            _healthyWorkers = count;
+        }
+
+        /// <inheritdoc />
+        public void SetStoppedWorkers(int count)
+        {
+            _stoppedWorkers = count;
+        }
+
+        /// <inheritdoc />
+        public void IncrementProcessingTasks()
+        {
+            System.Threading.Interlocked.Increment(ref _processingTasks);
+        }
+
+        /// <inheritdoc />
+        public void DecrementProcessingTasks()
+        {
+            System.Threading.Interlocked.Decrement(ref _processingTasks);
+        }
+
+        private static KeyValuePair<string, object>[] CreateTags(string queueName, string workerId)
+        {
+            return new[]
+            {
+                new KeyValuePair<string, object>("queue.name", queueName ?? "unknown"),
+                new KeyValuePair<string, object>("worker.id", workerId ?? "unknown")
+            };
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                _meter?.Dispose();
+            }
+
+            _disposed = true;
+        }
+    }
+}

--- a/src/MessageWorkerPool.OpenTelemetry/OpenTelemetryProvider.cs
+++ b/src/MessageWorkerPool.OpenTelemetry/OpenTelemetryProvider.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using MessageWorkerPool.Telemetry.Abstractions;
+
+namespace MessageWorkerPool.OpenTelemetry
+{
+    /// <summary>
+    /// OpenTelemetry implementation of ITelemetryProvider.
+    /// </summary>
+    public class OpenTelemetryProvider : ITelemetryProvider, IDisposable
+    {
+        private readonly ActivitySource _activitySource;
+        private readonly OpenTelemetryMetrics _metrics;
+
+        /// <summary>
+        /// Initializes a new instance of OpenTelemetryProvider.
+        /// </summary>
+        /// <param name="serviceName">The service name for telemetry.</param>
+        /// <param name="serviceVersion">The service version for telemetry.</param>
+        public OpenTelemetryProvider(string serviceName = "MessageWorkerPool", string serviceVersion = "1.0.0")
+        {
+            _activitySource = new ActivitySource(serviceName, serviceVersion);
+            _metrics = new OpenTelemetryMetrics(serviceName, serviceVersion);
+        }
+
+        /// <inheritdoc />
+        public IActivity StartActivity(
+            string operationName,
+            IDictionary<string, object> tags = null,
+            ActivityKind kind = ActivityKind.Internal,
+            ActivityContext parentContext = default)
+        {
+            Activity activity;
+
+            if (parentContext != default)
+            {
+                // Start activity with explicit parent context for distributed tracing
+                activity = _activitySource.StartActivity(operationName, kind, parentContext);
+            }
+            else
+            {
+                // Start activity with implicit parent (current activity)
+                activity = _activitySource.StartActivity(operationName, kind);
+            }
+
+            if (activity == null)
+                return null;
+
+            if (tags != null)
+            {
+                foreach (var tag in tags)
+                {
+                    activity.SetTag(tag.Key, tag.Value?.ToString());
+                }
+            }
+
+            return new OpenTelemetryActivity(activity);
+        }
+
+        /// <inheritdoc />
+        public IMetrics Metrics => _metrics;
+
+        /// <summary>
+        /// Disposes the telemetry provider.
+        /// </summary>
+        public void Dispose()
+        {
+            _activitySource?.Dispose();
+            _metrics?.Dispose();
+        }
+    }
+}

--- a/src/MessageWorkerPool.OpenTelemetry/README.md
+++ b/src/MessageWorkerPool.OpenTelemetry/README.md
@@ -1,0 +1,53 @@
+# MessageWorkerPool.OpenTelemetry
+
+OpenTelemetry extensions for MessageWorkerPool providing comprehensive observability with metrics and distributed tracing capabilities.
+
+## Features
+
+- **Metrics**: Monitor worker pool performance, message processing rates, and resource utilization
+- **Distributed Tracing**: Track message flow across worker processes with context propagation
+- **OpenTelemetry Integration**: Seamless integration with OpenTelemetry collectors and exporters
+- **Prometheus Support**: Built-in Prometheus HTTP listener exporter
+- **OTLP Support**: Export telemetry data using OpenTelemetry Protocol
+
+## Installation
+
+```bash
+dotnet add package MessageWorkerPool.OpenTelemetry
+```
+
+## Usage
+
+Add OpenTelemetry to your MessageWorkerPool application:
+
+```csharp
+using MessageWorkerPool.OpenTelemetry;
+
+// Configure OpenTelemetry in your service
+services.AddOpenTelemetry()
+    .WithMetrics(metrics =>
+    {
+        metrics.AddMessageWorkerPoolMetrics();
+    })
+    .WithTracing(tracing =>
+    {
+        tracing.AddMessageWorkerPoolTracing();
+    });
+```
+
+## Available Metrics
+
+The package provides various metrics including:
+- Message processing rate
+- Worker pool utilization
+- Message queue depth
+- Processing duration
+- Error rates
+
+## Distributed Tracing
+
+Trace context is automatically propagated across worker processes, enabling end-to-end visibility of message processing flows.
+
+## Documentation
+
+For more information, visit the [MessageWorkerPool repository](https://github.com/isdaniel/MessageWorkerPool).

--- a/src/MessageWorkerPool.OpenTelemetry/TraceContextPropagation.cs
+++ b/src/MessageWorkerPool.OpenTelemetry/TraceContextPropagation.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Text;
 
 namespace MessageWorkerPool.OpenTelemetry
 {
@@ -93,7 +94,7 @@ namespace MessageWorkerPool.OpenTelemetry
                 return str;
 
             if (value is byte[] bytes)
-                return System.Text.Encoding.UTF8.GetString(bytes);
+                return Encoding.UTF8.GetString(bytes);
 
             return value.ToString();
         }

--- a/src/MessageWorkerPool.OpenTelemetry/TraceContextPropagation.cs
+++ b/src/MessageWorkerPool.OpenTelemetry/TraceContextPropagation.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace MessageWorkerPool.OpenTelemetry
+{
+    /// <summary>
+    /// Helper class for propagating trace context through messaging systems.
+    /// Supports W3C Trace Context standard (traceparent and tracestate).
+    /// </summary>
+    public static class TraceContextPropagation
+    {
+        private const string TraceParentHeaderName = "traceparent";
+        private const string TraceStateHeaderName = "tracestate";
+
+        /// <summary>
+        /// Extracts parent activity context from message headers.
+        /// </summary>
+        /// <param name="headers">Message headers dictionary.</param>
+        /// <returns>ActivityContext if trace context is found, otherwise default.</returns>
+        public static ActivityContext ExtractTraceContext(IDictionary<string, object> headers)
+        {
+            if (headers == null || !headers.Any())
+                return default;
+
+            // Try to get traceparent header
+            if (!headers.TryGetValue(TraceParentHeaderName, out var traceParentObj))
+                return default;
+
+            string traceParent = ConvertToString(traceParentObj);
+            if (string.IsNullOrWhiteSpace(traceParent))
+                return default;
+
+            // Parse W3C traceparent format: version-traceId-spanId-traceFlags
+            // Example: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01
+            var parts = traceParent.Split('-');
+            if (parts.Length != 4)
+                return default;
+
+            try
+            {
+                var traceId = ActivityTraceId.CreateFromString(parts[1].AsSpan());
+                var spanId = ActivitySpanId.CreateFromString(parts[2].AsSpan());
+                var traceFlags = (ActivityTraceFlags)Convert.ToInt32(parts[3], 16);
+
+                // Try to get tracestate if present
+                string traceState = null;
+                if (headers.TryGetValue(TraceStateHeaderName, out var traceStateObj))
+                {
+                    traceState = ConvertToString(traceStateObj);
+                }
+
+                return new ActivityContext(traceId, spanId, traceFlags, traceState);
+            }
+            catch
+            {
+                // If parsing fails, return default context
+                return default;
+            }
+        }
+
+        /// <summary>
+        /// Injects current activity context into message headers.
+        /// </summary>
+        /// <param name="headers">Message headers dictionary to inject into.</param>
+        /// <param name="activity">The activity whose context to inject.</param>
+        public static void InjectTraceContext(IDictionary<string, object> headers, Activity activity)
+        {
+            if (headers == null || activity == null)
+                return;
+
+            // Create W3C traceparent: version-traceId-spanId-traceFlags
+            var traceParent = $"00-{activity.TraceId.ToHexString()}-{activity.SpanId.ToHexString()}-{((int)activity.ActivityTraceFlags):x2}";
+            headers[TraceParentHeaderName] = traceParent;
+
+            // Add tracestate if present
+            if (!string.IsNullOrWhiteSpace(activity.TraceStateString))
+            {
+                headers[TraceStateHeaderName] = activity.TraceStateString;
+            }
+        }
+
+        /// <summary>
+        /// Converts header value to string, handling byte arrays and other types.
+        /// </summary>
+        private static string ConvertToString(object value)
+        {
+            if (value == null)
+                return null;
+
+            if (value is string str)
+                return str;
+
+            if (value is byte[] bytes)
+                return System.Text.Encoding.UTF8.GetString(bytes);
+
+            return value.ToString();
+        }
+    }
+}

--- a/src/MessageWorkerPool.sln
+++ b/src/MessageWorkerPool.sln
@@ -5,7 +5,13 @@ VisualStudioVersion = 17.11.35431.28
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MessageWorkerPool", "MessageWorkerPool\MessageWorkerPool.csproj", "{51CED266-E4E3-43EC-9159-23F68194328A}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MessageWorkerPool.OpenTelemetry", "MessageWorkerPool.OpenTelemetry\MessageWorkerPool.OpenTelemetry.csproj", "{2A3B4C5D-6E7F-8901-2345-6789ABCDEF01}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MessageWorkerPool.Test", "tests\MessageWorkerPool.Test\MessageWorkerPool.Test.csproj", "{35FA9645-24F8-4E20-94EB-0BED7ACA0D8B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WorkerHost", "Examples\DotNetWorker\WorkerHost\WorkerHost.csproj", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WorkerClient", "Examples\DotNetWorker\WorkerClient\WorkerClient.csproj", "{3E05A61E-F83E-474F-BB6A-968342827573}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{CCB7A0F2-C13A-4838-87D1-76F275F8123C}"
 	ProjectSection(SolutionItems) = preProject
@@ -22,10 +28,22 @@ Global
 		{51CED266-E4E3-43EC-9159-23F68194328A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{51CED266-E4E3-43EC-9159-23F68194328A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{51CED266-E4E3-43EC-9159-23F68194328A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2A3B4C5D-6E7F-8901-2345-6789ABCDEF01}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2A3B4C5D-6E7F-8901-2345-6789ABCDEF01}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2A3B4C5D-6E7F-8901-2345-6789ABCDEF01}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2A3B4C5D-6E7F-8901-2345-6789ABCDEF01}.Release|Any CPU.Build.0 = Release|Any CPU
 		{35FA9645-24F8-4E20-94EB-0BED7ACA0D8B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{35FA9645-24F8-4E20-94EB-0BED7ACA0D8B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{35FA9645-24F8-4E20-94EB-0BED7ACA0D8B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{35FA9645-24F8-4E20-94EB-0BED7ACA0D8B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3E05A61E-F83E-474F-BB6A-968342827573}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3E05A61E-F83E-474F-BB6A-968342827573}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3E05A61E-F83E-474F-BB6A-968342827573}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3E05A61E-F83E-474F-BB6A-968342827573}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/MessageWorkerPool/MessageWorkerPool.csproj
+++ b/src/MessageWorkerPool/MessageWorkerPool.csproj
@@ -14,13 +14,13 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="MessagePack" Version="3.1.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
     <PackageReference Include="RabbitMQ.Client" Version="6.8.1" />
     <PackageReference Include="Confluent.Kafka" Version="2.6.1" />
+
     <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 

--- a/src/MessageWorkerPool/MessageWorkerPool.csproj
+++ b/src/MessageWorkerPool/MessageWorkerPool.csproj
@@ -9,7 +9,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://github.com/isdaniel/MessageWorkerPool</PackageProjectUrl>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <PackageReleaseNotes>New support Kafka worker pool, and rabbitMQ worker enhancement</PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/src/MessageWorkerPool/Telemetry/Abstractions/IActivity.cs
+++ b/src/MessageWorkerPool/Telemetry/Abstractions/IActivity.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+
+namespace MessageWorkerPool.Telemetry.Abstractions
+{
+    /// <summary>
+    /// Represents an activity/span for distributed tracing.
+    /// </summary>
+    public interface IActivity : IDisposable
+    {
+        /// <summary>
+        /// Adds a tag to the activity.
+        /// </summary>
+        /// <param name="key">The tag key.</param>
+        /// <param name="value">The tag value.</param>
+        void SetTag(string key, object value);
+
+        /// <summary>
+        /// Adds multiple tags to the activity.
+        /// </summary>
+        /// <param name="tags">The tags to add.</param>
+        void SetTags(IDictionary<string, object> tags);
+
+        /// <summary>
+        /// Sets the activity status.
+        /// </summary>
+        /// <param name="status">The status of the activity.</param>
+        /// <param name="description">Optional description of the status.</param>
+        void SetStatus(ActivityStatus status, string description = null);
+
+        /// <summary>
+        /// Records an exception that occurred during the activity.
+        /// </summary>
+        /// <param name="exception">The exception to record.</param>
+        void RecordException(Exception exception);
+    }
+
+    /// <summary>
+    /// Status of an activity.
+    /// </summary>
+    public enum ActivityStatus
+    {
+        /// <summary>
+        /// The activity completed successfully.
+        /// </summary>
+        Ok,
+
+        /// <summary>
+        /// The activity failed with an error.
+        /// </summary>
+        Error
+    }
+}

--- a/src/MessageWorkerPool/Telemetry/Abstractions/IMetrics.cs
+++ b/src/MessageWorkerPool/Telemetry/Abstractions/IMetrics.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+
+namespace MessageWorkerPool.Telemetry.Abstractions
+{
+    /// <summary>
+    /// Abstraction for recording metrics.
+    /// </summary>
+    public interface IMetrics
+    {
+        /// <summary>
+        /// Records a successfully processed task.
+        /// </summary>
+        /// <param name="queueName">The queue name where the task came from.</param>
+        /// <param name="workerId">The worker ID that processed the task.</param>
+        void RecordTaskProcessed(string queueName = null, string workerId = null);
+
+        /// <summary>
+        /// Records a failed task.
+        /// </summary>
+        /// <param name="queueName">The queue name where the task came from.</param>
+        /// <param name="workerId">The worker ID that processed the task.</param>
+        /// <param name="errorType">The type of error that occurred.</param>
+        void RecordTaskFailed(string queueName = null, string workerId = null, string errorType = null);
+
+        /// <summary>
+        /// Records a rejected task.
+        /// </summary>
+        /// <param name="queueName">The queue name where the task came from.</param>
+        /// <param name="workerId">The worker ID that rejected the task.</param>
+        void RecordTaskRejected(string queueName = null, string workerId = null);
+
+        /// <summary>
+        /// Records the duration of task processing.
+        /// </summary>
+        /// <param name="durationMs">Duration in milliseconds.</param>
+        /// <param name="queueName">The queue name where the task came from.</param>
+        /// <param name="workerId">The worker ID that processed the task.</param>
+        void RecordTaskDuration(double durationMs, string queueName = null, string workerId = null);
+
+        /// <summary>
+        /// Updates the number of active workers.
+        /// </summary>
+        void SetActiveWorkers(int count);
+
+        /// <summary>
+        /// Updates the number of tasks currently being processed.
+        /// </summary>
+        void SetProcessingTasks(int count);
+
+        /// <summary>
+        /// Updates the number of healthy workers.
+        /// </summary>
+        void SetHealthyWorkers(int count);
+
+        /// <summary>
+        /// Updates the number of stopped workers.
+        /// </summary>
+        void SetStoppedWorkers(int count);
+
+        /// <summary>
+        /// Increments the number of processing tasks.
+        /// </summary>
+        void IncrementProcessingTasks();
+
+        /// <summary>
+        /// Decrements the number of processing tasks.
+        /// </summary>
+        void DecrementProcessingTasks();
+    }
+}

--- a/src/MessageWorkerPool/Telemetry/Abstractions/ITelemetryProvider.cs
+++ b/src/MessageWorkerPool/Telemetry/Abstractions/ITelemetryProvider.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace MessageWorkerPool.Telemetry.Abstractions
+{
+    /// <summary>
+    /// Abstraction for telemetry providers (OpenTelemetry, Application Insights, etc.)
+    /// </summary>
+    public interface ITelemetryProvider
+    {
+        /// <summary>
+        /// Creates a new activity for tracing.
+        /// </summary>
+        /// <param name="operationName">The name of the operation.</param>
+        /// <param name="tags">Optional tags to add to the activity.</param>
+        /// <param name="kind">The kind of activity (Internal, Server, Client, Producer, Consumer).</param>
+        /// <param name="parentContext">Optional parent activity context for distributed tracing.</param>
+        /// <returns>An activity that should be disposed when the operation completes.</returns>
+        IActivity StartActivity(
+            string operationName,
+            IDictionary<string, object> tags = null,
+            ActivityKind kind = ActivityKind.Internal,
+            ActivityContext parentContext = default);
+
+        /// <summary>
+        /// Records metrics about worker operations.
+        /// </summary>
+        IMetrics Metrics { get; }
+    }
+}

--- a/src/MessageWorkerPool/Telemetry/NoOpTelemetryProvider.cs
+++ b/src/MessageWorkerPool/Telemetry/NoOpTelemetryProvider.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using MessageWorkerPool.Telemetry.Abstractions;
+
+namespace MessageWorkerPool.Telemetry
+{
+    /// <summary>
+    /// A no-operation telemetry provider that does nothing.
+    /// Used when telemetry is disabled.
+    /// </summary>
+    public class NoOpTelemetryProvider : ITelemetryProvider
+    {
+        /// <summary>
+        /// Singleton instance of the no-op telemetry provider.
+        /// </summary>
+        public static readonly NoOpTelemetryProvider Instance = new NoOpTelemetryProvider();
+
+        private NoOpTelemetryProvider() { }
+
+        /// <inheritdoc />
+        public IActivity StartActivity(
+            string operationName,
+            IDictionary<string, object> tags = null,
+            ActivityKind kind = ActivityKind.Internal,
+            ActivityContext parentContext = default)
+        {
+            return NoOpActivity.Instance;
+        }
+
+        /// <inheritdoc />
+        public IMetrics Metrics { get; } = NoOpMetrics.Instance;
+    }
+
+    /// <summary>
+    /// A no-operation activity that does nothing.
+    /// </summary>
+    public class NoOpActivity : IActivity
+    {
+        /// <summary>
+        /// Singleton instance of the no-op activity.
+        /// </summary>
+        public static readonly NoOpActivity Instance = new NoOpActivity();
+
+        private NoOpActivity() { }
+
+        /// <inheritdoc />
+        public void SetTag(string key, object value) { }
+
+        /// <inheritdoc />
+        public void SetTags(IDictionary<string, object> tags) { }
+
+        /// <inheritdoc />
+        public void SetStatus(ActivityStatus status, string description = null) { }
+
+        /// <inheritdoc />
+        public void RecordException(Exception exception) { }
+
+        /// <inheritdoc />
+        public void Dispose() { }
+    }
+
+    /// <summary>
+    /// A no-operation metrics recorder that does nothing.
+    /// </summary>
+    public class NoOpMetrics : IMetrics
+    {
+        /// <summary>
+        /// Singleton instance of the no-op metrics recorder.
+        /// </summary>
+        public static readonly NoOpMetrics Instance = new NoOpMetrics();
+
+        private NoOpMetrics() { }
+
+        /// <inheritdoc />
+        public void RecordTaskProcessed(string queueName = null, string workerId = null) { }
+
+        /// <inheritdoc />
+        public void RecordTaskFailed(string queueName = null, string workerId = null, string errorType = null) { }
+
+        /// <inheritdoc />
+        public void RecordTaskRejected(string queueName = null, string workerId = null) { }
+
+        /// <inheritdoc />
+        public void RecordTaskDuration(double durationMs, string queueName = null, string workerId = null) { }
+
+        /// <inheritdoc />
+        public void SetActiveWorkers(int count) { }
+
+        /// <inheritdoc />
+        public void SetProcessingTasks(int count) { }
+
+        /// <inheritdoc />
+        public void SetHealthyWorkers(int count) { }
+
+        /// <inheritdoc />
+        public void SetStoppedWorkers(int count) { }
+
+        /// <inheritdoc />
+        public void IncrementProcessingTasks() { }
+
+        /// <inheritdoc />
+        public void DecrementProcessingTasks() { }
+    }
+}

--- a/src/MessageWorkerPool/Telemetry/TaskProcessingTelemetry.cs
+++ b/src/MessageWorkerPool/Telemetry/TaskProcessingTelemetry.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Diagnostics;
+using MessageWorkerPool.Utilities;
+using MessageWorkerPool.Telemetry.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace MessageWorkerPool.Telemetry
+{
+    /// <summary>
+    /// Encapsulates telemetry recording for task processing using AOP principles.
+    /// Handles metrics, activity tracking, and logging for a single task lifecycle.
+    /// </summary>
+    public sealed class TaskProcessingTelemetry : IDisposable
+    {
+        private readonly Stopwatch _stopwatch;
+        private readonly IActivity _activity;
+        private readonly ILogger _logger;
+        private readonly string _queueName;
+        private readonly string _workerId;
+        private bool _disposed;
+        private bool _recorded;
+
+        /// <summary>
+        /// Initializes a new instance of TaskProcessingTelemetry.
+        /// </summary>
+        /// <param name="workerId">The worker ID processing the task.</param>
+        /// <param name="queueName">The queue name from which the task originated.</param>
+        /// <param name="correlationId">The correlation ID of the task.</param>
+        /// <param name="logger">The logger instance.</param>
+        /// <param name="messageHeaders">Optional message headers for trace context propagation.</param>
+        public TaskProcessingTelemetry(
+            string workerId,
+            string queueName,
+            string correlationId,
+            ILogger logger,
+            System.Collections.Generic.IDictionary<string, object> messageHeaders = null)
+        {
+            _workerId = workerId;
+            _queueName = queueName;
+            _logger = logger;
+
+            _stopwatch = Stopwatch.StartNew();
+            _activity = TelemetryManager.StartTaskProcessingActivity(workerId, queueName, correlationId, messageHeaders);
+
+            TelemetryManager.Metrics?.IncrementProcessingTasks();
+        }
+
+        /// <summary>
+        /// Sets additional tags on the activity.
+        /// </summary>
+        public void SetTag(string key, object value)
+        {
+            _activity?.SetTag(key, value);
+        }
+
+        /// <summary>
+        /// Records a successful task completion.
+        /// </summary>
+        /// <param name="status">The message status.</param>
+        public void RecordSuccess(MessageStatus status)
+        {
+            if (_recorded) return;
+
+            _stopwatch.Stop();
+            TelemetryManager.Metrics?.RecordTaskProcessed(_queueName, _workerId);
+            TelemetryManager.Metrics?.RecordTaskDuration(_stopwatch.Elapsed.TotalMilliseconds, _queueName, _workerId);
+            TelemetryManager.SetTaskStatus(_activity, status);
+
+            _recorded = true;
+        }
+
+        /// <summary>
+        /// Records a rejected task.
+        /// </summary>
+        /// <param name="status">The message status.</param>
+        public void RecordRejection(MessageStatus status)
+        {
+            if (_recorded) return;
+
+            _stopwatch.Stop();
+            TelemetryManager.Metrics?.RecordTaskRejected(_queueName, _workerId);
+            TelemetryManager.Metrics?.RecordTaskDuration(_stopwatch.Elapsed.TotalMilliseconds, _queueName, _workerId);
+            TelemetryManager.SetTaskStatus(_activity, status);
+
+            _recorded = true;
+        }
+
+        /// <summary>
+        /// Records a failed task with exception details.
+        /// </summary>
+        /// <param name="exception">The exception that occurred.</param>
+        public void RecordFailure(Exception exception)
+        {
+            if (_recorded) return;
+
+            _stopwatch.Stop();
+            TelemetryManager.Metrics?.RecordTaskFailed(_queueName, _workerId, exception.GetType().Name);
+            TelemetryManager.Metrics?.RecordTaskDuration(_stopwatch.Elapsed.TotalMilliseconds, _queueName, _workerId);
+            TelemetryManager.RecordException(_activity, exception);
+
+            _logger?.LogWarning(exception, "Processing message encountered an exception!");
+
+            _recorded = true;
+        }
+
+        /// <summary>
+        /// Disposes the telemetry context and decrements processing tasks counter.
+        /// </summary>
+        public void Dispose()
+        {
+            if (_disposed) return;
+
+            TelemetryManager.Metrics?.DecrementProcessingTasks();
+            _activity?.Dispose();
+            _disposed = true;
+        }
+    }
+}

--- a/src/MessageWorkerPool/Telemetry/TelemetryManager.cs
+++ b/src/MessageWorkerPool/Telemetry/TelemetryManager.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Diagnostics;
+using MessageWorkerPool.Telemetry.Abstractions;
+using MessageWorkerPool.Utilities;
+
+namespace MessageWorkerPool.Telemetry
+{
+    /// <summary>
+    /// Central telemetry manager for WorkerPool operations.
+    /// Provides a unified interface for all telemetry activities.
+    /// </summary>
+    public static class TelemetryManager
+    {
+        private static ITelemetryProvider _provider = NoOpTelemetryProvider.Instance;
+        private static Func<System.Collections.Generic.IDictionary<string, object>, System.Diagnostics.ActivityContext> _contextExtractor;
+
+        /// <summary>
+        /// Sets the telemetry provider to use.
+        /// </summary>
+        /// <param name="provider">The telemetry provider.</param>
+        public static void SetProvider(ITelemetryProvider provider)
+        {
+            _provider = provider ?? throw new ArgumentNullException(nameof(provider));
+        }
+
+        /// <summary>
+        /// Sets a custom trace context extractor for extracting parent context from message headers.
+        /// </summary>
+        /// <param name="extractor">Function to extract ActivityContext from message headers.</param>
+        public static void SetTraceContextExtractor(Func<System.Collections.Generic.IDictionary<string, object>, System.Diagnostics.ActivityContext> extractor)
+        {
+            _contextExtractor = extractor;
+        }
+
+        /// <summary>
+        /// Gets the current telemetry provider.
+        /// </summary>
+        public static ITelemetryProvider Provider => _provider;
+
+        /// <summary>
+        /// Starts a new activity for worker initialization.
+        /// </summary>
+        /// <param name="workerId">The worker ID.</param>
+        /// <param name="queueName">The queue name.</param>
+        /// <returns>An Activity instance or null if not enabled.</returns>
+        public static IActivity StartWorkerInitActivity(string workerId, string queueName)
+        {
+            var activity = _provider.StartActivity("Worker.Init");
+            activity?.SetTag("worker.id", workerId);
+            activity?.SetTag("queue.name", queueName);
+            return activity;
+        }
+
+        /// <summary>
+        /// Starts a new activity for task processing.
+        /// </summary>
+        /// <param name="workerId">The worker ID.</param>
+        /// <param name="queueName">The queue name.</param>
+        /// <param name="correlationId">The correlation ID of the task.</param>
+        /// <param name="messageHeaders">Optional message headers for trace context propagation.</param>
+        /// <returns>An Activity instance or null if not enabled.</returns>
+        public static IActivity StartTaskProcessingActivity(
+            string workerId,
+            string queueName,
+            string correlationId,
+            System.Collections.Generic.IDictionary<string, object> messageHeaders = null)
+        {
+            // Extract parent context from message headers if available
+            System.Diagnostics.ActivityContext parentContext = default;
+            if (messageHeaders != null && _contextExtractor != null)
+            {
+                try
+                {
+                    parentContext = _contextExtractor(messageHeaders);
+                }
+                catch
+                {
+                    // If context extraction fails, continue without parent context
+                }
+            }
+
+            // Use ActivityKind.Consumer for message processing activities
+            var activity = _provider.StartActivity("Worker.ProcessTask", null, System.Diagnostics.ActivityKind.Consumer, parentContext);
+
+            // Set individual tags on the activity
+            activity?.SetTag("worker.id", workerId);
+            activity?.SetTag("queue.name", queueName);
+            activity?.SetTag("correlation.id", correlationId);
+            activity?.SetTag("messaging.system", "rabbitmq");
+            activity?.SetTag("messaging.destination", queueName);
+            activity?.SetTag("messaging.operation", "process");
+
+            return activity;
+        }
+
+        /// <summary>
+        /// Starts a new activity for worker pool initialization.
+        /// </summary>
+        /// <param name="workerCount">The number of workers in the pool.</param>
+        /// <param name="queueName">The queue name.</param>
+        /// <returns>An Activity instance or null if not enabled.</returns>
+        public static IActivity StartPoolInitActivity(int workerCount, string queueName)
+        {
+            var activity = _provider.StartActivity("WorkerPool.Init");
+            activity?.SetTag("workerpool.worker_count", workerCount);
+            activity?.SetTag("queue.name", queueName);
+            return activity;
+        }
+
+        /// <summary>
+        /// Starts a new activity for graceful shutdown.
+        /// </summary>
+        /// <param name="workerId">The worker ID.</param>
+        /// <returns>An Activity instance or null if not enabled.</returns>
+        public static IActivity StartShutdownActivity(string workerId)
+        {
+            var activity = _provider.StartActivity("Worker.Shutdown");
+            activity?.SetTag("worker.id", workerId);
+            return activity;
+        }
+
+        /// <summary>
+        /// Records an exception in the given activity.
+        /// </summary>
+        /// <param name="activity">The activity to record the exception in.</param>
+        /// <param name="exception">The exception to record.</param>
+        public static void RecordException(IActivity activity, Exception exception)
+        {
+            if (activity == null || exception == null)
+                return;
+
+            activity.SetStatus(ActivityStatus.Error, exception.Message);
+            activity.RecordException(exception);
+        }
+
+        /// <summary>
+        /// Sets the status of a task processing activity based on MessageStatus.
+        /// </summary>
+        /// <param name="activity">The activity to update.</param>
+        /// <param name="status">The message status.</param>
+        public static void SetTaskStatus(IActivity activity, MessageStatus status)
+        {
+            if (activity == null)
+                return;
+
+            activity.SetTag("message.status", status.ToString());
+
+            switch (status)
+            {
+                case MessageStatus.MESSAGE_DONE:
+                case MessageStatus.MESSAGE_DONE_WITH_REPLY:
+                    activity.SetStatus(ActivityStatus.Ok);
+                    break;
+                case MessageStatus.IGNORE_MESSAGE:
+                    activity.SetStatus(ActivityStatus.Error, "Message ignored");
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Gets the metrics recorder.
+        /// </summary>
+        public static IMetrics Metrics => _provider.Metrics;
+    }
+}

--- a/src/MessageWorkerPool/Telemetry/WorkerPoolInformation.cs
+++ b/src/MessageWorkerPool/Telemetry/WorkerPoolInformation.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MessageWorkerPool.Utilities;
+
+namespace MessageWorkerPool.Telemetry
+{
+    /// <summary>
+    /// Collects and provides basic information about workers and worker pools.
+    /// </summary>
+    public class WorkerPoolInformation
+    {
+        /// <summary>
+        /// Gets or sets the worker pool ID.
+        /// </summary>
+        public string PoolId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the queue name being processed.
+        /// </summary>
+        public string QueueName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the total number of workers configured.
+        /// </summary>
+        public int TotalWorkers { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of healthy (running) workers.
+        /// </summary>
+        public int HealthyWorkers { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of stopped workers.
+        /// </summary>
+        public int StoppedWorkers { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of stopping workers.
+        /// </summary>
+        public int StoppingWorkers { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of workers waiting for initialization.
+        /// </summary>
+        public int WaitingWorkers { get; set; }
+
+        /// <summary>
+        /// Gets or sets the command line used to start workers.
+        /// </summary>
+        public string CommandLine { get; set; }
+
+        /// <summary>
+        /// Gets or sets the creation time of the pool.
+        /// </summary>
+        public DateTime CreatedAt { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether the pool is closed.
+        /// </summary>
+        public bool IsClosed { get; set; }
+
+        /// <summary>
+        /// Gets detailed information about individual workers.
+        /// </summary>
+        public List<WorkerInformation> Workers { get; set; } = new List<WorkerInformation>();
+
+        /// <summary>
+        /// Calculates worker health percentage.
+        /// </summary>
+        public double HealthPercentage
+        {
+            get
+            {
+                if (TotalWorkers == 0) return 0;
+                return (double)HealthyWorkers / TotalWorkers * 100;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Contains detailed information about an individual worker.
+    /// </summary>
+    public class WorkerInformation
+    {
+        /// <summary>
+        /// Gets or sets the worker ID (usually process ID).
+        /// </summary>
+        public string WorkerId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the process ID.
+        /// </summary>
+        public int ProcessId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the current status of the worker.
+        /// </summary>
+        public WorkerStatus Status { get; set; }
+
+        /// <summary>
+        /// Gets or sets the queue name this worker is consuming from.
+        /// </summary>
+        public string QueueName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the total number of tasks processed by this worker.
+        /// </summary>
+        public long TasksProcessed { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of tasks currently being processed.
+        /// </summary>
+        public int CurrentTaskCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the creation time of the worker.
+        /// </summary>
+        public DateTime CreatedAt { get; set; }
+
+        /// <summary>
+        /// Gets or sets the last activity time of the worker.
+        /// </summary>
+        public DateTime LastActivityAt { get; set; }
+
+        /// <summary>
+        /// Determines if the worker is healthy (running status).
+        /// </summary>
+        public bool IsHealthy => Status == WorkerStatus.Running;
+    }
+
+    /// <summary>
+    /// Helper class to collect worker pool information from a WorkerPoolBase instance.
+    /// </summary>
+    public static class WorkerPoolInformationCollector
+    {
+        /// <summary>
+        /// Collects basic information from workers for telemetry purposes.
+        /// </summary>
+        /// <param name="workers">The list of workers to collect information from.</param>
+        /// <param name="queueName">The queue name being processed.</param>
+        /// <returns>A summary of worker statuses.</returns>
+        public static WorkerStatusSummary CollectWorkerStatus(IEnumerable<IWorker> workers, string queueName)
+        {
+            var summary = new WorkerStatusSummary
+            {
+                QueueName = queueName,
+                TotalWorkers = workers.Count()
+            };
+
+            foreach (var worker in workers)
+            {
+                if (worker is WorkerBase workerBase)
+                {
+                    switch (workerBase.Status)
+                    {
+                        case WorkerStatus.Running:
+                            summary.HealthyWorkers++;
+                            break;
+                        case WorkerStatus.Stopped:
+                            summary.StoppedWorkers++;
+                            break;
+                        case WorkerStatus.Stopping:
+                            summary.StoppingWorkers++;
+                            break;
+                        case WorkerStatus.WaitForInit:
+                            summary.WaitingWorkers++;
+                            break;
+                    }
+                }
+            }
+
+            return summary;
+        }
+    }
+
+    /// <summary>
+    /// Summary of worker statuses in a pool.
+    /// </summary>
+    public class WorkerStatusSummary
+    {
+        public string QueueName { get; set; }
+        public int TotalWorkers { get; set; }
+        public int HealthyWorkers { get; set; }
+        public int StoppedWorkers { get; set; }
+        public int StoppingWorkers { get; set; }
+        public int WaitingWorkers { get; set; }
+    }
+}

--- a/src/MessageWorkerPool/Utilities/MessageStatus.cs
+++ b/src/MessageWorkerPool/Utilities/MessageStatus.cs
@@ -12,6 +12,7 @@ namespace MessageWorkerPool.Utilities
     public enum MessageStatus : short {
         IGNORE_MESSAGE = -1,
         MESSAGE_DONE = 200,
-        MESSAGE_DONE_WITH_REPLY = 201
+        MESSAGE_DONE_WITH_REPLY = 201,
+        UNKNOWN_ERROR = 500
     }
 }

--- a/src/tests/MessageWorkerPool.Test/MessageWorkerPool.Test.csproj
+++ b/src/tests/MessageWorkerPool.Test/MessageWorkerPool.Test.csproj
@@ -29,6 +29,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\MessageWorkerPool\MessageWorkerPool.csproj" />
+    <ProjectReference Include="..\..\MessageWorkerPool.OpenTelemetry\MessageWorkerPool.OpenTelemetry.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/tests/MessageWorkerPool.Test/OpenTelemetry/MessageWorkerPoolOpenTelemetryExtensionsTests.cs
+++ b/src/tests/MessageWorkerPool.Test/OpenTelemetry/MessageWorkerPoolOpenTelemetryExtensionsTests.cs
@@ -1,0 +1,477 @@
+using FluentAssertions;
+using MessageWorkerPool.OpenTelemetry.Extensions;
+using MessageWorkerPool.Telemetry;
+using MessageWorkerPool.Telemetry.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+using System;
+using Xunit;
+
+namespace MessageWorkerPool.Test.OpenTelemetry.Extensions
+{
+    [Collection("TelemetryTests")]
+    public class MessageWorkerPoolOpenTelemetryExtensionsTests : IDisposable
+    {
+        public void Dispose()
+        {
+            // Clean up - reset to NoOp provider after each test
+            TelemetryManager.SetProvider(NoOpTelemetryProvider.Instance);
+            TelemetryManager.SetTraceContextExtractor(null);
+        }
+
+        [Fact]
+        public void AddMessageWorkerPoolOpenTelemetry_ShouldSetOpenTelemetryProvider()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act
+            services.AddMessageWorkerPoolOpenTelemetry();
+
+            // Assert
+            TelemetryManager.Provider.Should().BeOfType<MessageWorkerPool.OpenTelemetry.OpenTelemetryProvider>();
+        }
+
+        [Fact]
+        public void AddMessageWorkerPoolOpenTelemetry_WithCustomServiceName_ShouldSetProviderWithCustomName()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act
+            services.AddMessageWorkerPoolOpenTelemetry("CustomService", "2.0.0");
+
+            // Assert
+            var provider = TelemetryManager.Provider as MessageWorkerPool.OpenTelemetry.OpenTelemetryProvider;
+            provider.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void AddMessageWorkerPoolOpenTelemetry_ShouldSetTraceContextExtractor()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act
+            services.AddMessageWorkerPoolOpenTelemetry();
+
+            // Assert - Verify extractor is set by testing extraction
+            var headers = new System.Collections.Generic.Dictionary<string, object>
+            {
+                { "traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01" }
+            };
+
+            // Create a new telemetry instance which will use the extractor
+            var telemetry = new TaskProcessingTelemetry("worker-1", "test-queue", "corr-123", null, headers);
+            telemetry.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void AddMessageWorkerPoolOpenTelemetry_WithDefaultParameters_ShouldUseDefaultValues()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act
+            var result = services.AddMessageWorkerPoolOpenTelemetry();
+
+            // Assert
+            result.Should().BeSameAs(services);
+            TelemetryManager.Provider.Should().BeOfType<MessageWorkerPool.OpenTelemetry.OpenTelemetryProvider>();
+        }
+
+        [Fact]
+        public void AddMessageWorkerPoolInstrumentation_MeterProviderBuilder_WithNullBuilder_ShouldThrowArgumentNullException()
+        {
+            // Arrange
+            MeterProviderBuilder builder = null;
+
+            // Act
+            Action act = () => builder.AddMessageWorkerPoolInstrumentation();
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>().WithParameterName("builder");
+        }
+
+        [Fact]
+        public void AddMessageWorkerPoolInstrumentation_MeterProviderBuilder_ShouldReturnBuilder()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            services.AddOpenTelemetry()
+                .WithMetrics(metrics =>
+                {
+                    // Act
+                    var result = metrics.AddMessageWorkerPoolInstrumentation();
+
+                    // Assert
+                    result.Should().BeSameAs(metrics);
+                });
+        }
+
+        [Fact]
+        public void AddMessageWorkerPoolInstrumentation_MeterProviderBuilder_WithCustomServiceName_ShouldAddMeter()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            
+            // Act & Assert
+            services.AddOpenTelemetry()
+                .WithMetrics(metrics =>
+                {
+                    var result = metrics.AddMessageWorkerPoolInstrumentation("CustomService");
+                    result.Should().BeSameAs(metrics);
+                });
+        }
+
+        [Fact]
+        public void AddMessageWorkerPoolInstrumentation_TracerProviderBuilder_WithNullBuilder_ShouldThrowArgumentNullException()
+        {
+            // Arrange
+            TracerProviderBuilder builder = null;
+
+            // Act
+            Action act = () => builder.AddMessageWorkerPoolInstrumentation();
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>().WithParameterName("builder");
+        }
+
+        [Fact]
+        public void AddMessageWorkerPoolInstrumentation_TracerProviderBuilder_ShouldReturnBuilder()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            services.AddOpenTelemetry()
+                .WithTracing(tracing =>
+                {
+                    // Act
+                    var result = tracing.AddMessageWorkerPoolInstrumentation();
+
+                    // Assert
+                    result.Should().BeSameAs(tracing);
+                });
+        }
+
+        [Fact]
+        public void AddMessageWorkerPoolInstrumentation_TracerProviderBuilder_WithCustomServiceName_ShouldAddSource()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            
+            // Act & Assert
+            services.AddOpenTelemetry()
+                .WithTracing(tracing =>
+                {
+                    var result = tracing.AddMessageWorkerPoolInstrumentation("CustomService");
+                    result.Should().BeSameAs(tracing);
+                });
+        }
+
+        [Fact]
+        public void AddMessageWorkerPoolTelemetry_WithoutConfiguration_ShouldUseDefaultOptions()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act
+            var result = services.AddMessageWorkerPoolTelemetry();
+
+            // Assert
+            result.Should().BeSameAs(services);
+            TelemetryManager.Provider.Should().BeOfType<MessageWorkerPool.OpenTelemetry.OpenTelemetryProvider>();
+        }
+
+        [Fact]
+        public void AddMessageWorkerPoolTelemetry_WithConfiguration_ShouldApplyOptions()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act
+            services.AddMessageWorkerPoolTelemetry(options =>
+            {
+                options.ServiceName = "TestService";
+                options.ServiceVersion = "3.0.0";
+                options.EnableRuntimeInstrumentation = false;
+                options.EnableProcessInstrumentation = false;
+            });
+
+            // Assert
+            TelemetryManager.Provider.Should().BeOfType<MessageWorkerPool.OpenTelemetry.OpenTelemetryProvider>();
+        }
+
+        [Fact]
+        public void AddMessageWorkerPoolTelemetry_WithCustomMetricsConfiguration_ShouldApplyConfiguration()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            bool metricsConfigured = false;
+
+            // Act
+            services.AddMessageWorkerPoolTelemetry(options =>
+            {
+                options.ConfigureMetrics = metrics =>
+                {
+                    metricsConfigured = true;
+                };
+            });
+
+            // Assert
+            metricsConfigured.Should().BeTrue();
+        }
+
+        [Fact]
+        public void AddMessageWorkerPoolTelemetry_WithCustomTracingConfiguration_ShouldApplyConfiguration()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            bool tracingConfigured = false;
+
+            // Act
+            services.AddMessageWorkerPoolTelemetry(options =>
+            {
+                options.ConfigureTracing = tracing =>
+                {
+                    tracingConfigured = true;
+                };
+            });
+
+            // Assert
+            tracingConfigured.Should().BeTrue();
+        }
+
+        [Fact]
+        public void AddMessageWorkerPoolTelemetry_WithRuntimeInstrumentationEnabled_ShouldConfigureCorrectly()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act
+            services.AddMessageWorkerPoolTelemetry(options =>
+            {
+                options.EnableRuntimeInstrumentation = true;
+                options.EnableProcessInstrumentation = false;
+            });
+
+            // Assert
+            TelemetryManager.Provider.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void AddMessageWorkerPoolTelemetry_WithProcessInstrumentationEnabled_ShouldConfigureCorrectly()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act
+            services.AddMessageWorkerPoolTelemetry(options =>
+            {
+                options.EnableRuntimeInstrumentation = false;
+                options.EnableProcessInstrumentation = true;
+            });
+
+            // Assert
+            TelemetryManager.Provider.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void AddMessageWorkerPoolTelemetry_WithAllInstrumentationDisabled_ShouldStillConfigure()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act
+            services.AddMessageWorkerPoolTelemetry(options =>
+            {
+                options.EnableRuntimeInstrumentation = false;
+                options.EnableProcessInstrumentation = false;
+            });
+
+            // Assert
+            TelemetryManager.Provider.Should().BeOfType<MessageWorkerPool.OpenTelemetry.OpenTelemetryProvider>();
+        }
+
+        [Fact]
+        public void AddMessageWorkerPoolTelemetry_ShouldSetTraceContextExtractor()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act
+            services.AddMessageWorkerPoolTelemetry();
+
+            // Assert - Verify extractor is set
+            var headers = new System.Collections.Generic.Dictionary<string, object>
+            {
+                { "traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01" }
+            };
+
+            var telemetry = new TaskProcessingTelemetry("worker-1", "test-queue", "corr-123", null, headers);
+            telemetry.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void MessageWorkerPoolTelemetryOptions_DefaultValues_ShouldBeCorrect()
+        {
+            // Act
+            var options = new MessageWorkerPoolTelemetryOptions();
+
+            // Assert
+            options.ServiceName.Should().Be("MessageWorkerPool");
+            options.ServiceVersion.Should().Be("1.0.0");
+            options.EnableRuntimeInstrumentation.Should().BeTrue();
+            options.EnableProcessInstrumentation.Should().BeTrue();
+            options.ConfigureMetrics.Should().BeNull();
+            options.ConfigureTracing.Should().BeNull();
+        }
+
+        [Fact]
+        public void MessageWorkerPoolTelemetryOptions_ServiceName_CanBeSet()
+        {
+            // Arrange
+            var options = new MessageWorkerPoolTelemetryOptions();
+
+            // Act
+            options.ServiceName = "CustomService";
+
+            // Assert
+            options.ServiceName.Should().Be("CustomService");
+        }
+
+        [Fact]
+        public void MessageWorkerPoolTelemetryOptions_ServiceVersion_CanBeSet()
+        {
+            // Arrange
+            var options = new MessageWorkerPoolTelemetryOptions();
+
+            // Act
+            options.ServiceVersion = "2.5.0";
+
+            // Assert
+            options.ServiceVersion.Should().Be("2.5.0");
+        }
+
+        [Fact]
+        public void MessageWorkerPoolTelemetryOptions_EnableRuntimeInstrumentation_CanBeSet()
+        {
+            // Arrange
+            var options = new MessageWorkerPoolTelemetryOptions();
+
+            // Act
+            options.EnableRuntimeInstrumentation = false;
+
+            // Assert
+            options.EnableRuntimeInstrumentation.Should().BeFalse();
+        }
+
+        [Fact]
+        public void MessageWorkerPoolTelemetryOptions_EnableProcessInstrumentation_CanBeSet()
+        {
+            // Arrange
+            var options = new MessageWorkerPoolTelemetryOptions();
+
+            // Act
+            options.EnableProcessInstrumentation = false;
+
+            // Assert
+            options.EnableProcessInstrumentation.Should().BeFalse();
+        }
+
+        [Fact]
+        public void MessageWorkerPoolTelemetryOptions_ConfigureMetrics_CanBeSet()
+        {
+            // Arrange
+            var options = new MessageWorkerPoolTelemetryOptions();
+            Action<MeterProviderBuilder> configureAction = metrics => { };
+
+            // Act
+            options.ConfigureMetrics = configureAction;
+
+            // Assert
+            options.ConfigureMetrics.Should().BeSameAs(configureAction);
+        }
+
+        [Fact]
+        public void MessageWorkerPoolTelemetryOptions_ConfigureTracing_CanBeSet()
+        {
+            // Arrange
+            var options = new MessageWorkerPoolTelemetryOptions();
+            Action<TracerProviderBuilder> configureAction = tracing => { };
+
+            // Act
+            options.ConfigureTracing = configureAction;
+
+            // Assert
+            options.ConfigureTracing.Should().BeSameAs(configureAction);
+        }
+
+        [Fact]
+        public void AddMessageWorkerPoolTelemetry_WithNullConfiguration_ShouldUseDefaultOptions()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act
+            services.AddMessageWorkerPoolTelemetry(null);
+
+            // Assert
+            TelemetryManager.Provider.Should().BeOfType<MessageWorkerPool.OpenTelemetry.OpenTelemetryProvider>();
+        }
+
+        [Fact]
+        public void AddMessageWorkerPoolTelemetry_ShouldConfigureResourceWithServiceInfo()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act
+            services.AddMessageWorkerPoolTelemetry(options =>
+            {
+                options.ServiceName = "TestWorkerPool";
+                options.ServiceVersion = "1.2.3";
+            });
+
+            // Build the service provider to ensure configuration is applied
+            var serviceProvider = services.BuildServiceProvider();
+
+            // Assert
+            TelemetryManager.Provider.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void AddMessageWorkerPoolTelemetry_CalledMultipleTimes_ShouldNotThrow()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act
+            Action act = () =>
+            {
+                services.AddMessageWorkerPoolTelemetry();
+                services.AddMessageWorkerPoolTelemetry();
+            };
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void AddMessageWorkerPoolOpenTelemetry_CalledMultipleTimes_ShouldNotThrow()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act
+            Action act = () =>
+            {
+                services.AddMessageWorkerPoolOpenTelemetry();
+                services.AddMessageWorkerPoolOpenTelemetry();
+            };
+
+            // Assert
+            act.Should().NotThrow();
+        }
+    }
+}

--- a/src/tests/MessageWorkerPool.Test/OpenTelemetry/OpenTelemetryActivityTests.cs
+++ b/src/tests/MessageWorkerPool.Test/OpenTelemetry/OpenTelemetryActivityTests.cs
@@ -1,0 +1,418 @@
+using FluentAssertions;
+using MessageWorkerPool.OpenTelemetry;
+using MessageWorkerPool.Telemetry.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Xunit;
+
+namespace MessageWorkerPool.Test.OpenTelemetry
+{
+    public class OpenTelemetryActivityTests : IDisposable
+    {
+        private readonly ActivitySource _activitySource;
+        private readonly ActivityListener _listener;
+        private readonly List<Activity> _activities;
+
+        public OpenTelemetryActivityTests()
+        {
+            _activitySource = new ActivitySource("TestSource", "1.0.0");
+            _activities = new List<Activity>();
+            
+            _listener = new ActivityListener
+            {
+                ShouldListenTo = source => source.Name == "TestSource",
+                Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllDataAndRecorded,
+                ActivityStarted = activity => _activities.Add(activity)
+            };
+            ActivitySource.AddActivityListener(_listener);
+        }
+
+        public void Dispose()
+        {
+            _activitySource?.Dispose();
+            _listener?.Dispose();
+        }
+
+        [Fact]
+        public void Constructor_WithNullActivity_ShouldThrowArgumentNullException()
+        {
+            // Act
+            Action act = () => new OpenTelemetryActivity(null);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>().WithParameterName("activity");
+        }
+
+        [Fact]
+        public void Constructor_WithValidActivity_ShouldCreateInstance()
+        {
+            // Arrange
+            var activity = _activitySource.StartActivity("TestOperation");
+
+            // Act
+            var otelActivity = new OpenTelemetryActivity(activity);
+
+            // Assert
+            otelActivity.Should().NotBeNull();
+            
+            // Cleanup
+            otelActivity.Dispose();
+        }
+
+        [Fact]
+        public void SetTag_ShouldSetTagOnUnderlyingActivity()
+        {
+            // Arrange
+            var activity = _activitySource.StartActivity("TestOperation");
+            var otelActivity = new OpenTelemetryActivity(activity);
+
+            // Act
+            otelActivity.SetTag("test.key", "test.value");
+
+            // Assert
+            activity.GetTagItem("test.key").Should().Be("test.value");
+            
+            // Cleanup
+            otelActivity.Dispose();
+        }
+
+        [Fact]
+        public void SetTag_WithNullKey_ShouldNotThrow()
+        {
+            // Arrange
+            var activity = _activitySource.StartActivity("TestOperation");
+            var otelActivity = new OpenTelemetryActivity(activity);
+
+            // Act
+            Action act = () => otelActivity.SetTag(null, "value");
+
+            // Assert
+            act.Should().NotThrow();
+            
+            // Cleanup
+            otelActivity.Dispose();
+        }
+
+        [Fact]
+        public void SetTag_WithEmptyKey_ShouldNotThrow()
+        {
+            // Arrange
+            var activity = _activitySource.StartActivity("TestOperation");
+            var otelActivity = new OpenTelemetryActivity(activity);
+
+            // Act
+            Action act = () => otelActivity.SetTag(string.Empty, "value");
+
+            // Assert
+            act.Should().NotThrow();
+            
+            // Cleanup
+            otelActivity.Dispose();
+        }
+
+        [Fact]
+        public void SetTag_WithNullValue_ShouldNotThrow()
+        {
+            // Arrange
+            var activity = _activitySource.StartActivity("TestOperation");
+            var otelActivity = new OpenTelemetryActivity(activity);
+
+            // Act
+            Action act = () => otelActivity.SetTag("key", null);
+
+            // Assert
+            act.Should().NotThrow();
+            
+            // Cleanup
+            otelActivity.Dispose();
+        }
+
+        [Fact]
+        public void SetTag_WithNumericValue_ShouldConvertToString()
+        {
+            // Arrange
+            var activity = _activitySource.StartActivity("TestOperation");
+            var otelActivity = new OpenTelemetryActivity(activity);
+
+            // Act
+            otelActivity.SetTag("number", 42);
+
+            // Assert
+            activity.GetTagItem("number").Should().Be("42");
+            
+            // Cleanup
+            otelActivity.Dispose();
+        }
+
+        [Fact]
+        public void SetTags_WithMultipleTags_ShouldSetAllTags()
+        {
+            // Arrange
+            var activity = _activitySource.StartActivity("TestOperation");
+            var otelActivity = new OpenTelemetryActivity(activity);
+            var tags = new Dictionary<string, object>
+            {
+                { "tag1", "value1" },
+                { "tag2", 42 },
+                { "tag3", true }
+            };
+
+            // Act
+            otelActivity.SetTags(tags);
+
+            // Assert
+            activity.GetTagItem("tag1").Should().Be("value1");
+            activity.GetTagItem("tag2").Should().Be("42");
+            activity.GetTagItem("tag3").Should().Be("True");
+            
+            // Cleanup
+            otelActivity.Dispose();
+        }
+
+        [Fact]
+        public void SetTags_WithNullDictionary_ShouldNotThrow()
+        {
+            // Arrange
+            var activity = _activitySource.StartActivity("TestOperation");
+            var otelActivity = new OpenTelemetryActivity(activity);
+
+            // Act
+            Action act = () => otelActivity.SetTags(null);
+
+            // Assert
+            act.Should().NotThrow();
+            
+            // Cleanup
+            otelActivity.Dispose();
+        }
+
+        [Fact]
+        public void SetTags_WithEmptyDictionary_ShouldNotThrow()
+        {
+            // Arrange
+            var activity = _activitySource.StartActivity("TestOperation");
+            var otelActivity = new OpenTelemetryActivity(activity);
+
+            // Act
+            Action act = () => otelActivity.SetTags(new Dictionary<string, object>());
+
+            // Assert
+            act.Should().NotThrow();
+            
+            // Cleanup
+            otelActivity.Dispose();
+        }
+
+        [Fact]
+        public void SetStatus_WithOkStatus_ShouldSetActivityStatus()
+        {
+            // Arrange
+            var activity = _activitySource.StartActivity("TestOperation");
+            var otelActivity = new OpenTelemetryActivity(activity);
+
+            // Act
+            otelActivity.SetStatus(ActivityStatus.Ok);
+
+            // Assert
+            activity.Status.Should().Be(ActivityStatusCode.Ok);
+            
+            // Cleanup
+            otelActivity.Dispose();
+        }
+
+        [Fact]
+        public void SetStatus_WithErrorStatus_ShouldSetActivityStatus()
+        {
+            // Arrange
+            var activity = _activitySource.StartActivity("TestOperation");
+            var otelActivity = new OpenTelemetryActivity(activity);
+
+            // Act
+            otelActivity.SetStatus(ActivityStatus.Error, "Test error");
+
+            // Assert
+            activity.Status.Should().Be(ActivityStatusCode.Error);
+            activity.StatusDescription.Should().Be("Test error");
+            
+            // Cleanup
+            otelActivity.Dispose();
+        }
+
+        [Fact]
+        public void SetStatus_WithNullDescription_ShouldNotThrow()
+        {
+            // Arrange
+            var activity = _activitySource.StartActivity("TestOperation");
+            var otelActivity = new OpenTelemetryActivity(activity);
+
+            // Act
+            Action act = () => otelActivity.SetStatus(ActivityStatus.Ok, null);
+
+            // Assert
+            act.Should().NotThrow();
+            
+            // Cleanup
+            otelActivity.Dispose();
+        }
+
+        [Fact]
+        public void RecordException_ShouldSetExceptionTags()
+        {
+            // Arrange
+            var activity = _activitySource.StartActivity("TestOperation");
+            var otelActivity = new OpenTelemetryActivity(activity);
+            
+            // Create an exception with a stack trace by actually throwing it
+            Exception exception = null;
+            try
+            {
+                throw new InvalidOperationException("Test exception");
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+
+            // Act
+            otelActivity.RecordException(exception);
+
+            // Assert
+            activity.GetTagItem("exception.type").Should().Be("System.InvalidOperationException");
+            activity.GetTagItem("exception.message").Should().Be("Test exception");
+            // Stack trace should exist since we actually threw the exception
+            var stackTrace = activity.GetTagItem("exception.stacktrace") as string;
+            stackTrace.Should().NotBeNullOrEmpty();
+            
+            // Cleanup
+            otelActivity.Dispose();
+        }
+
+        [Fact]
+        public void RecordException_WithNullException_ShouldNotThrow()
+        {
+            // Arrange
+            var activity = _activitySource.StartActivity("TestOperation");
+            var otelActivity = new OpenTelemetryActivity(activity);
+
+            // Act
+            Action act = () => otelActivity.RecordException(null);
+
+            // Assert
+            act.Should().NotThrow();
+            
+            // Cleanup
+            otelActivity.Dispose();
+        }
+
+        [Fact]
+        public void RecordException_WithExceptionWithStackTrace_ShouldCaptureStackTrace()
+        {
+            // Arrange
+            var activity = _activitySource.StartActivity("TestOperation");
+            var otelActivity = new OpenTelemetryActivity(activity);
+            
+            Exception exception = null;
+            try
+            {
+                throw new InvalidOperationException("Test with stack trace");
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+
+            // Act
+            otelActivity.RecordException(exception);
+
+            // Assert
+            var stackTrace = activity.GetTagItem("exception.stacktrace") as string;
+            stackTrace.Should().NotBeNullOrEmpty();
+            stackTrace.Should().Contain("RecordException_WithExceptionWithStackTrace_ShouldCaptureStackTrace");
+            
+            // Cleanup
+            otelActivity.Dispose();
+        }
+
+        [Fact]
+        public void Dispose_ShouldDisposeUnderlyingActivity()
+        {
+            // Arrange
+            var activity = _activitySource.StartActivity("TestOperation");
+            var otelActivity = new OpenTelemetryActivity(activity);
+
+            // Act
+            otelActivity.Dispose();
+
+            // Assert - Activity should be stopped/disposed
+            // We can't directly verify disposal, but we can check operations after disposal don't throw
+            Action act = () => otelActivity.SetTag("test", "value");
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Dispose_CalledMultipleTimes_ShouldNotThrow()
+        {
+            // Arrange
+            var activity = _activitySource.StartActivity("TestOperation");
+            var otelActivity = new OpenTelemetryActivity(activity);
+
+            // Act
+            Action act = () =>
+            {
+                otelActivity.Dispose();
+                otelActivity.Dispose();
+                otelActivity.Dispose();
+            };
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void SetTag_AfterDispose_ShouldNotThrow()
+        {
+            // Arrange
+            var activity = _activitySource.StartActivity("TestOperation");
+            var otelActivity = new OpenTelemetryActivity(activity);
+            otelActivity.Dispose();
+
+            // Act
+            Action act = () => otelActivity.SetTag("test", "value");
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void SetStatus_AfterDispose_ShouldNotThrow()
+        {
+            // Arrange
+            var activity = _activitySource.StartActivity("TestOperation");
+            var otelActivity = new OpenTelemetryActivity(activity);
+            otelActivity.Dispose();
+
+            // Act
+            Action act = () => otelActivity.SetStatus(ActivityStatus.Ok);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void RecordException_AfterDispose_ShouldNotThrow()
+        {
+            // Arrange
+            var activity = _activitySource.StartActivity("TestOperation");
+            var otelActivity = new OpenTelemetryActivity(activity);
+            otelActivity.Dispose();
+            var exception = new InvalidOperationException("Test");
+
+            // Act
+            Action act = () => otelActivity.RecordException(exception);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+    }
+}

--- a/src/tests/MessageWorkerPool.Test/OpenTelemetry/OpenTelemetryMetricsTests.cs
+++ b/src/tests/MessageWorkerPool.Test/OpenTelemetry/OpenTelemetryMetricsTests.cs
@@ -1,0 +1,416 @@
+using FluentAssertions;
+using MessageWorkerPool.OpenTelemetry;
+using System;
+using System.Diagnostics.Metrics;
+using System.Linq;
+using Xunit;
+
+namespace MessageWorkerPool.Test.OpenTelemetry
+{
+    public class OpenTelemetryMetricsTests : IDisposable
+    {
+        private readonly OpenTelemetryMetrics _metrics;
+
+        public OpenTelemetryMetricsTests()
+        {
+            _metrics = new OpenTelemetryMetrics("TestMeter", "1.0.0");
+        }
+
+        public void Dispose()
+        {
+            _metrics?.Dispose();
+        }
+
+        [Fact]
+        public void Constructor_WithDefaultParameters_ShouldCreateInstance()
+        {
+            // Arrange & Act
+            using var metrics = new OpenTelemetryMetrics();
+
+            // Assert
+            metrics.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void Constructor_WithCustomParameters_ShouldCreateInstance()
+        {
+            // Arrange & Act
+            using var metrics = new OpenTelemetryMetrics("CustomMeter", "2.0.0");
+
+            // Assert
+            metrics.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void RecordTaskProcessed_ShouldNotThrow()
+        {
+            // Act
+            Action act = () => _metrics.RecordTaskProcessed("test-queue", "worker-1");
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void RecordTaskProcessed_WithNullParameters_ShouldNotThrow()
+        {
+            // Act
+            Action act = () => _metrics.RecordTaskProcessed(null, null);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void RecordTaskFailed_ShouldNotThrow()
+        {
+            // Act
+            Action act = () => _metrics.RecordTaskFailed("test-queue", "worker-1", "InvalidOperationException");
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void RecordTaskFailed_WithNullErrorType_ShouldNotThrow()
+        {
+            // Act
+            Action act = () => _metrics.RecordTaskFailed("test-queue", "worker-1", null);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void RecordTaskFailed_WithAllNullParameters_ShouldNotThrow()
+        {
+            // Act
+            Action act = () => _metrics.RecordTaskFailed(null, null, null);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void RecordTaskRejected_ShouldNotThrow()
+        {
+            // Act
+            Action act = () => _metrics.RecordTaskRejected("test-queue", "worker-1");
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void RecordTaskRejected_WithNullParameters_ShouldNotThrow()
+        {
+            // Act
+            Action act = () => _metrics.RecordTaskRejected(null, null);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void RecordTaskDuration_ShouldNotThrow()
+        {
+            // Act
+            Action act = () => _metrics.RecordTaskDuration(123.45, "test-queue", "worker-1");
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void RecordTaskDuration_WithZeroDuration_ShouldNotThrow()
+        {
+            // Act
+            Action act = () => _metrics.RecordTaskDuration(0, "test-queue", "worker-1");
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void RecordTaskDuration_WithNegativeDuration_ShouldNotThrow()
+        {
+            // Act
+            Action act = () => _metrics.RecordTaskDuration(-100, "test-queue", "worker-1");
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void RecordTaskDuration_ConvertsMillisecondsToSeconds()
+        {
+            // Arrange - 1000ms should be converted to 1 second
+            // We can't directly verify the value, but we can ensure the method executes
+
+            // Act
+            Action act = () => _metrics.RecordTaskDuration(1000, "test-queue", "worker-1");
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void SetActiveWorkers_ShouldNotThrow()
+        {
+            // Act
+            Action act = () => _metrics.SetActiveWorkers(5);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void SetActiveWorkers_WithZero_ShouldNotThrow()
+        {
+            // Act
+            Action act = () => _metrics.SetActiveWorkers(0);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void SetActiveWorkers_WithNegative_ShouldNotThrow()
+        {
+            // Act
+            Action act = () => _metrics.SetActiveWorkers(-1);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void SetProcessingTasks_ShouldNotThrow()
+        {
+            // Act
+            Action act = () => _metrics.SetProcessingTasks(10);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void SetHealthyWorkers_ShouldNotThrow()
+        {
+            // Act
+            Action act = () => _metrics.SetHealthyWorkers(3);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void SetStoppedWorkers_ShouldNotThrow()
+        {
+            // Act
+            Action act = () => _metrics.SetStoppedWorkers(2);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void IncrementProcessingTasks_ShouldIncrement()
+        {
+            // Act - Call multiple times
+            _metrics.IncrementProcessingTasks();
+            _metrics.IncrementProcessingTasks();
+            _metrics.IncrementProcessingTasks();
+
+            // Assert - Should not throw
+            Action act = () => _metrics.IncrementProcessingTasks();
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void DecrementProcessingTasks_ShouldDecrement()
+        {
+            // Arrange - Increment first
+            _metrics.IncrementProcessingTasks();
+            _metrics.IncrementProcessingTasks();
+
+            // Act
+            _metrics.DecrementProcessingTasks();
+
+            // Assert - Should not throw
+            Action act = () => _metrics.DecrementProcessingTasks();
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void IncrementAndDecrementProcessingTasks_ShouldBeThreadSafe()
+        {
+            // Arrange
+            var tasks = new System.Threading.Tasks.Task[100];
+
+            // Act - Perform concurrent increments and decrements
+            for (int i = 0; i < 50; i++)
+            {
+                tasks[i * 2] = System.Threading.Tasks.Task.Run(() => _metrics.IncrementProcessingTasks());
+                tasks[i * 2 + 1] = System.Threading.Tasks.Task.Run(() => _metrics.DecrementProcessingTasks());
+            }
+
+            // Assert - Should not throw
+            Action act = () => System.Threading.Tasks.Task.WaitAll(tasks);
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Dispose_ShouldDisposeResourcesWithoutError()
+        {
+            // Arrange
+            var metrics = new OpenTelemetryMetrics("TestMeter", "1.0.0");
+
+            // Act
+            Action act = () => metrics.Dispose();
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Dispose_CalledMultipleTimes_ShouldNotThrow()
+        {
+            // Arrange
+            var metrics = new OpenTelemetryMetrics("TestMeter", "1.0.0");
+
+            // Act
+            Action act = () =>
+            {
+                metrics.Dispose();
+                metrics.Dispose();
+                metrics.Dispose();
+            };
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void RecordTaskProcessed_AfterDispose_ShouldNotThrow()
+        {
+            // Arrange
+            var metrics = new OpenTelemetryMetrics("TestMeter", "1.0.0");
+            metrics.Dispose();
+
+            // Act
+            Action act = () => metrics.RecordTaskProcessed("queue", "worker");
+
+            // Assert - Behavior after disposal may vary, but shouldn't crash
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void MultipleMetricOperations_ShouldWorkTogether()
+        {
+            // Act & Assert - Simulate realistic usage
+            Action act = () =>
+            {
+                _metrics.SetActiveWorkers(5);
+                _metrics.IncrementProcessingTasks();
+                _metrics.RecordTaskProcessed("test-queue", "worker-1");
+                _metrics.RecordTaskDuration(100.5, "test-queue", "worker-1");
+                _metrics.DecrementProcessingTasks();
+                _metrics.SetHealthyWorkers(5);
+                _metrics.RecordTaskFailed("test-queue", "worker-2", "Exception");
+                _metrics.RecordTaskRejected("test-queue", "worker-3");
+                _metrics.SetStoppedWorkers(0);
+            };
+
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void RecordTaskDuration_WithLargeValue_ShouldNotThrow()
+        {
+            // Act
+            Action act = () => _metrics.RecordTaskDuration(double.MaxValue, "test-queue", "worker-1");
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void SetActiveWorkers_MultipleTimesShouldUpdateValue()
+        {
+            // Act & Assert - Each call should succeed
+            Action act = () =>
+            {
+                _metrics.SetActiveWorkers(1);
+                _metrics.SetActiveWorkers(5);
+                _metrics.SetActiveWorkers(10);
+                _metrics.SetActiveWorkers(0);
+            };
+
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void RecordMultipleTasksProcessed_ShouldNotThrow()
+        {
+            // Act
+            Action act = () =>
+            {
+                for (int i = 0; i < 100; i++)
+                {
+                    _metrics.RecordTaskProcessed($"queue-{i % 3}", $"worker-{i % 5}");
+                }
+            };
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void RecordTaskFailed_WithDifferentErrorTypes_ShouldNotThrow()
+        {
+            // Act
+            Action act = () =>
+            {
+                _metrics.RecordTaskFailed("queue", "worker", "InvalidOperationException");
+                _metrics.RecordTaskFailed("queue", "worker", "ArgumentException");
+                _metrics.RecordTaskFailed("queue", "worker", "NullReferenceException");
+            };
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void IncrementProcessingTasks_CalledManyTimes_ShouldNotThrow()
+        {
+            // Act
+            Action act = () =>
+            {
+                for (int i = 0; i < 1000; i++)
+                {
+                    _metrics.IncrementProcessingTasks();
+                }
+            };
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void DecrementProcessingTasks_BelowZero_ShouldNotThrow()
+        {
+            // Act - Decrement without incrementing first
+            Action act = () =>
+            {
+                for (int i = 0; i < 10; i++)
+                {
+                    _metrics.DecrementProcessingTasks();
+                }
+            };
+
+            // Assert - Should handle negative values gracefully
+            act.Should().NotThrow();
+        }
+    }
+}

--- a/src/tests/MessageWorkerPool.Test/OpenTelemetry/OpenTelemetryProviderTests.cs
+++ b/src/tests/MessageWorkerPool.Test/OpenTelemetry/OpenTelemetryProviderTests.cs
@@ -1,0 +1,213 @@
+using FluentAssertions;
+using MessageWorkerPool.OpenTelemetry;
+using MessageWorkerPool.Telemetry.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Xunit;
+
+namespace MessageWorkerPool.Test.OpenTelemetry
+{
+    public class OpenTelemetryProviderTests : IDisposable
+    {
+        private readonly OpenTelemetryProvider _provider;
+        private readonly ActivityListener _listener;
+        private readonly List<Activity> _activities;
+
+        public OpenTelemetryProviderTests()
+        {
+            _provider = new OpenTelemetryProvider("TestService", "1.0.0");
+            _activities = new List<Activity>();
+            
+            _listener = new ActivityListener
+            {
+                ShouldListenTo = source => source.Name == "TestService",
+                Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllDataAndRecorded,
+                ActivityStarted = activity => _activities.Add(activity)
+            };
+            ActivitySource.AddActivityListener(_listener);
+        }
+
+        public void Dispose()
+        {
+            _provider?.Dispose();
+            _listener?.Dispose();
+        }
+
+        [Fact]
+        public void Constructor_WithDefaultParameters_ShouldCreateProvider()
+        {
+            // Arrange & Act
+            using var provider = new OpenTelemetryProvider();
+
+            // Assert
+            provider.Should().NotBeNull();
+            provider.Metrics.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void Constructor_WithCustomParameters_ShouldCreateProvider()
+        {
+            // Arrange & Act
+            using var provider = new OpenTelemetryProvider("CustomService", "2.0.0");
+
+            // Assert
+            provider.Should().NotBeNull();
+            provider.Metrics.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void StartActivity_WithOperationName_ShouldCreateActivity()
+        {
+            // Act
+            using var activity = _provider.StartActivity("TestOperation");
+
+            // Assert
+            activity.Should().NotBeNull();
+            activity.Should().BeOfType<OpenTelemetryActivity>();
+            _activities.Should().HaveCount(1);
+            _activities[0].OperationName.Should().Be("TestOperation");
+        }
+
+        [Fact]
+        public void StartActivity_WithTags_ShouldSetTagsOnActivity()
+        {
+            // Arrange
+            var tags = new Dictionary<string, object>
+            {
+                { "tag1", "value1" },
+                { "tag2", 42 },
+                { "tag3", true }
+            };
+
+            // Act
+            using var activity = _provider.StartActivity("TestOperation", tags);
+
+            // Assert
+            activity.Should().NotBeNull();
+            _activities.Should().HaveCount(1);
+            var underlyingActivity = _activities[0];
+            underlyingActivity.GetTagItem("tag1").Should().Be("value1");
+            underlyingActivity.GetTagItem("tag2").Should().Be("42");
+            underlyingActivity.GetTagItem("tag3").Should().Be("True");
+        }
+
+        [Fact]
+        public void StartActivity_WithNullTags_ShouldNotThrow()
+        {
+            // Act
+            Action act = () =>
+            {
+                using var activity = _provider.StartActivity("TestOperation", null);
+            };
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void StartActivity_WithEmptyTags_ShouldNotThrow()
+        {
+            // Arrange
+            var tags = new Dictionary<string, object>();
+
+            // Act
+            Action act = () =>
+            {
+                using var activity = _provider.StartActivity("TestOperation", tags);
+            };
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Metrics_ShouldReturnOpenTelemetryMetrics()
+        {
+            // Act
+            var metrics = _provider.Metrics;
+
+            // Assert
+            metrics.Should().NotBeNull();
+            metrics.Should().BeOfType<OpenTelemetryMetrics>();
+        }
+
+        [Fact]
+        public void Metrics_CalledMultipleTimes_ShouldReturnSameInstance()
+        {
+            // Act
+            var metrics1 = _provider.Metrics;
+            var metrics2 = _provider.Metrics;
+
+            // Assert
+            metrics1.Should().BeSameAs(metrics2);
+        }
+
+        [Fact]
+        public void Dispose_ShouldDisposeResourcesWithoutError()
+        {
+            // Arrange
+            var provider = new OpenTelemetryProvider("TestService", "1.0.0");
+
+            // Act
+            Action act = () => provider.Dispose();
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Dispose_CalledMultipleTimes_ShouldNotThrow()
+        {
+            // Arrange
+            var provider = new OpenTelemetryProvider("TestService", "1.0.0");
+
+            // Act
+            Action act = () =>
+            {
+                provider.Dispose();
+                provider.Dispose();
+                provider.Dispose();
+            };
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void StartActivity_AfterDispose_ShouldReturnNull()
+        {
+            // Arrange
+            var provider = new OpenTelemetryProvider("TestService", "1.0.0");
+            provider.Dispose();
+
+            // Act
+            var activity = provider.StartActivity("TestOperation");
+
+            // Assert - After disposal, ActivitySource won't create new activities
+            // The behavior depends on the underlying implementation
+            // We just verify it doesn't throw
+        }
+
+        [Fact]
+        public void StartActivity_WithNullTagValue_ShouldHandleGracefully()
+        {
+            // Arrange
+            var tags = new Dictionary<string, object>
+            {
+                { "tag1", null },
+                { "tag2", "value2" }
+            };
+
+            // Act
+            Action act = () =>
+            {
+                using var activity = _provider.StartActivity("TestOperation", tags);
+            };
+
+            // Assert
+            act.Should().NotThrow();
+        }
+    }
+}

--- a/src/tests/MessageWorkerPool.Test/OpenTelemetry/TraceContextPropagationTests.cs
+++ b/src/tests/MessageWorkerPool.Test/OpenTelemetry/TraceContextPropagationTests.cs
@@ -1,0 +1,537 @@
+using FluentAssertions;
+using MessageWorkerPool.OpenTelemetry;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace MessageWorkerPool.Test.OpenTelemetry
+{
+    public class TraceContextPropagationTests : IDisposable
+    {
+        private readonly ActivityListener _listener;
+        private readonly ActivitySource _activitySource;
+
+        public TraceContextPropagationTests()
+        {
+            _activitySource = new ActivitySource("test-source");
+            
+            // Create and start an ActivityListener to enable activity creation
+            _listener = new ActivityListener
+            {
+                ShouldListenTo = source => source.Name == "test-source",
+                Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData
+            };
+            ActivitySource.AddActivityListener(_listener);
+        }
+
+        public void Dispose()
+        {
+            _listener?.Dispose();
+            _activitySource?.Dispose();
+        }
+
+        [Fact]
+        public void ExtractTraceContext_WithValidTraceParent_ShouldReturnActivityContext()
+        {
+            // Arrange
+            var headers = new Dictionary<string, object>
+            {
+                { "traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01" }
+            };
+
+            // Act
+            var context = TraceContextPropagation.ExtractTraceContext(headers);
+
+            // Assert
+            context.Should().NotBe(default(ActivityContext));
+            context.TraceId.Should().Be(ActivityTraceId.CreateFromString("0af7651916cd43dd8448eb211c80319c".AsSpan()));
+            context.SpanId.Should().Be(ActivitySpanId.CreateFromString("b7ad6b7169203331".AsSpan()));
+            context.TraceFlags.Should().Be(ActivityTraceFlags.Recorded);
+        }
+
+        [Fact]
+        public void ExtractTraceContext_WithTraceParentAndTraceState_ShouldReturnContextWithTraceState()
+        {
+            // Arrange
+            var headers = new Dictionary<string, object>
+            {
+                { "traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01" },
+                { "tracestate", "congo=t61rcWkgMzE" }
+            };
+
+            // Act
+            var context = TraceContextPropagation.ExtractTraceContext(headers);
+
+            // Assert
+            context.Should().NotBe(default(ActivityContext));
+            context.TraceState.Should().Be("congo=t61rcWkgMzE");
+        }
+
+        [Fact]
+        public void ExtractTraceContext_WithNullHeaders_ShouldReturnDefaultContext()
+        {
+            // Act
+            var context = TraceContextPropagation.ExtractTraceContext(null);
+
+            // Assert
+            context.Should().Be(default(ActivityContext));
+        }
+
+        [Fact]
+        public void ExtractTraceContext_WithEmptyHeaders_ShouldReturnDefaultContext()
+        {
+            // Arrange
+            var headers = new Dictionary<string, object>();
+
+            // Act
+            var context = TraceContextPropagation.ExtractTraceContext(headers);
+
+            // Assert
+            context.Should().Be(default(ActivityContext));
+        }
+
+        [Fact]
+        public void ExtractTraceContext_WithMissingTraceParent_ShouldReturnDefaultContext()
+        {
+            // Arrange
+            var headers = new Dictionary<string, object>
+            {
+                { "other-header", "value" }
+            };
+
+            // Act
+            var context = TraceContextPropagation.ExtractTraceContext(headers);
+
+            // Assert
+            context.Should().Be(default(ActivityContext));
+        }
+
+        [Fact]
+        public void ExtractTraceContext_WithNullTraceParent_ShouldReturnDefaultContext()
+        {
+            // Arrange
+            var headers = new Dictionary<string, object>
+            {
+                { "traceparent", null }
+            };
+
+            // Act
+            var context = TraceContextPropagation.ExtractTraceContext(headers);
+
+            // Assert
+            context.Should().Be(default(ActivityContext));
+        }
+
+        [Fact]
+        public void ExtractTraceContext_WithEmptyTraceParent_ShouldReturnDefaultContext()
+        {
+            // Arrange
+            var headers = new Dictionary<string, object>
+            {
+                { "traceparent", "" }
+            };
+
+            // Act
+            var context = TraceContextPropagation.ExtractTraceContext(headers);
+
+            // Assert
+            context.Should().Be(default(ActivityContext));
+        }
+
+        [Fact]
+        public void ExtractTraceContext_WithWhitespaceTraceParent_ShouldReturnDefaultContext()
+        {
+            // Arrange
+            var headers = new Dictionary<string, object>
+            {
+                { "traceparent", "   " }
+            };
+
+            // Act
+            var context = TraceContextPropagation.ExtractTraceContext(headers);
+
+            // Assert
+            context.Should().Be(default(ActivityContext));
+        }
+
+        [Fact]
+        public void ExtractTraceContext_WithInvalidFormat_TooFewParts_ShouldReturnDefaultContext()
+        {
+            // Arrange
+            var headers = new Dictionary<string, object>
+            {
+                { "traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331" }
+            };
+
+            // Act
+            var context = TraceContextPropagation.ExtractTraceContext(headers);
+
+            // Assert
+            context.Should().Be(default(ActivityContext));
+        }
+
+        [Fact]
+        public void ExtractTraceContext_WithInvalidFormat_TooManyParts_ShouldReturnDefaultContext()
+        {
+            // Arrange
+            var headers = new Dictionary<string, object>
+            {
+                { "traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01-extra" }
+            };
+
+            // Act
+            var context = TraceContextPropagation.ExtractTraceContext(headers);
+
+            // Assert
+            context.Should().Be(default(ActivityContext));
+        }
+
+        [Fact]
+        public void ExtractTraceContext_WithInvalidTraceId_ShouldReturnDefaultContext()
+        {
+            // Arrange
+            var headers = new Dictionary<string, object>
+            {
+                { "traceparent", "00-invalid-trace-id-b7ad6b7169203331-01" }
+            };
+
+            // Act
+            var context = TraceContextPropagation.ExtractTraceContext(headers);
+
+            // Assert
+            context.Should().Be(default(ActivityContext));
+        }
+
+        [Fact]
+        public void ExtractTraceContext_WithInvalidSpanId_ShouldReturnDefaultContext()
+        {
+            // Arrange
+            var headers = new Dictionary<string, object>
+            {
+                { "traceparent", "00-0af7651916cd43dd8448eb211c80319c-invalid-span-01" }
+            };
+
+            // Act
+            var context = TraceContextPropagation.ExtractTraceContext(headers);
+
+            // Assert
+            context.Should().Be(default(ActivityContext));
+        }
+
+        [Fact]
+        public void ExtractTraceContext_WithInvalidTraceFlags_ShouldReturnDefaultContext()
+        {
+            // Arrange
+            var headers = new Dictionary<string, object>
+            {
+                { "traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-zz" }
+            };
+
+            // Act
+            var context = TraceContextPropagation.ExtractTraceContext(headers);
+
+            // Assert
+            context.Should().Be(default(ActivityContext));
+        }
+
+        [Fact]
+        public void ExtractTraceContext_WithByteArrayTraceParent_ShouldParseCorrectly()
+        {
+            // Arrange
+            var traceParentBytes = Encoding.UTF8.GetBytes("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01");
+            var headers = new Dictionary<string, object>
+            {
+                { "traceparent", traceParentBytes }
+            };
+
+            // Act
+            var context = TraceContextPropagation.ExtractTraceContext(headers);
+
+            // Assert
+            context.Should().NotBe(default(ActivityContext));
+            context.TraceId.Should().Be(ActivityTraceId.CreateFromString("0af7651916cd43dd8448eb211c80319c".AsSpan()));
+            context.SpanId.Should().Be(ActivitySpanId.CreateFromString("b7ad6b7169203331".AsSpan()));
+        }
+
+        [Fact]
+        public void ExtractTraceContext_WithByteArrayTraceState_ShouldParseCorrectly()
+        {
+            // Arrange
+            var traceStateBytes = Encoding.UTF8.GetBytes("congo=t61rcWkgMzE");
+            var headers = new Dictionary<string, object>
+            {
+                { "traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01" },
+                { "tracestate", traceStateBytes }
+            };
+
+            // Act
+            var context = TraceContextPropagation.ExtractTraceContext(headers);
+
+            // Assert
+            context.TraceState.Should().Be("congo=t61rcWkgMzE");
+        }
+
+        [Fact]
+        public void ExtractTraceContext_WithNonStringNonByteArrayType_ShouldCallToString()
+        {
+            // Arrange
+            var headers = new Dictionary<string, object>
+            {
+                { "traceparent", new TraceParentWrapper("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01") }
+            };
+
+            // Act
+            var context = TraceContextPropagation.ExtractTraceContext(headers);
+
+            // Assert
+            context.Should().NotBe(default(ActivityContext));
+            context.TraceId.Should().Be(ActivityTraceId.CreateFromString("0af7651916cd43dd8448eb211c80319c".AsSpan()));
+        }
+
+        [Fact]
+        public void ExtractTraceContext_WithTraceFlagsZero_ShouldSetNoneFlags()
+        {
+            // Arrange
+            var headers = new Dictionary<string, object>
+            {
+                { "traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00" }
+            };
+
+            // Act
+            var context = TraceContextPropagation.ExtractTraceContext(headers);
+
+            // Assert
+            context.TraceFlags.Should().Be(ActivityTraceFlags.None);
+        }
+
+        [Fact]
+        public void InjectTraceContext_WithValidActivity_ShouldInjectTraceParent()
+        {
+            // Arrange
+            var headers = new Dictionary<string, object>();
+            using var activity = _activitySource.StartActivity("test-activity", ActivityKind.Internal);
+
+            // Act
+            TraceContextPropagation.InjectTraceContext(headers, activity);
+
+            // Assert
+            headers.Should().ContainKey("traceparent");
+            headers["traceparent"].Should().BeOfType<string>();
+            var traceparent = headers["traceparent"] as string;
+            traceparent.Should().StartWith("00-");
+            traceparent.Split('-').Should().HaveCount(4);
+        }
+
+        [Fact]
+        public void InjectTraceContext_WithActivityWithTraceState_ShouldInjectTraceState()
+        {
+            // Arrange
+            var headers = new Dictionary<string, object>();
+            using var activity = _activitySource.StartActivity("test-activity", ActivityKind.Internal);
+            activity.TraceStateString = "congo=t61rcWkgMzE";
+
+            // Act
+            TraceContextPropagation.InjectTraceContext(headers, activity);
+
+            // Assert
+            headers.Should().ContainKey("traceparent");
+            headers.Should().ContainKey("tracestate");
+            headers["tracestate"].Should().Be("congo=t61rcWkgMzE");
+        }
+
+        [Fact]
+        public void InjectTraceContext_WithNullHeaders_ShouldNotThrow()
+        {
+            // Arrange
+            using var activity = _activitySource.StartActivity("test-activity", ActivityKind.Internal);
+
+            // Act
+            Action act = () => TraceContextPropagation.InjectTraceContext(null, activity);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void InjectTraceContext_WithNullActivity_ShouldNotThrow()
+        {
+            // Arrange
+            var headers = new Dictionary<string, object>();
+
+            // Act
+            Action act = () => TraceContextPropagation.InjectTraceContext(headers, null);
+
+            // Assert
+            act.Should().NotThrow();
+            headers.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void InjectTraceContext_WithBothNull_ShouldNotThrow()
+        {
+            // Act
+            Action act = () => TraceContextPropagation.InjectTraceContext(null, null);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void InjectTraceContext_WithActivityWithoutTraceState_ShouldNotInjectTraceState()
+        {
+            // Arrange
+            var headers = new Dictionary<string, object>();
+            using var activity = _activitySource.StartActivity("test-activity", ActivityKind.Internal);
+
+            // Act
+            TraceContextPropagation.InjectTraceContext(headers, activity);
+
+            // Assert
+            headers.Should().ContainKey("traceparent");
+            headers.Should().NotContainKey("tracestate");
+        }
+
+        [Fact]
+        public void InjectTraceContext_WithActivityWithEmptyTraceState_ShouldNotInjectTraceState()
+        {
+            // Arrange
+            var headers = new Dictionary<string, object>();
+            using var activity = _activitySource.StartActivity("test-activity", ActivityKind.Internal);
+            if (activity != null)
+            {
+                activity.TraceStateString = "";
+            }
+
+            // Act
+            TraceContextPropagation.InjectTraceContext(headers, activity);
+
+            // Assert
+            headers.Should().ContainKey("traceparent");
+            headers.Should().NotContainKey("tracestate");
+        }
+
+        [Fact]
+        public void InjectTraceContext_WithActivityWithWhitespaceTraceState_ShouldNotInjectTraceState()
+        {
+            // Arrange
+            var headers = new Dictionary<string, object>();
+            using var activity = _activitySource.StartActivity("test-activity", ActivityKind.Internal);
+            if (activity != null)
+            {
+                activity.TraceStateString = "   ";
+            }
+
+            // Act
+            TraceContextPropagation.InjectTraceContext(headers, activity);
+
+            // Assert
+            headers.Should().ContainKey("traceparent");
+            headers.Should().NotContainKey("tracestate");
+        }
+
+        [Fact]
+        public void InjectAndExtract_RoundTrip_ShouldPreserveContext()
+        {
+            // Arrange
+            using var originalActivity = _activitySource.StartActivity("test-activity", ActivityKind.Internal);
+            // Note: TraceStateString might not be properly set on all .NET versions
+            // So we'll test the round-trip without it first
+            
+            var headers = new Dictionary<string, object>();
+
+            // Act - Inject
+            TraceContextPropagation.InjectTraceContext(headers, originalActivity);
+            
+            // Act - Extract
+            var extractedContext = TraceContextPropagation.ExtractTraceContext(headers);
+
+            // Assert
+            extractedContext.TraceId.Should().Be(originalActivity.TraceId);
+            extractedContext.SpanId.Should().Be(originalActivity.SpanId);
+            extractedContext.TraceFlags.Should().Be(originalActivity.ActivityTraceFlags);
+        }
+
+        [Fact]
+        public void InjectAndExtract_RoundTrip_WithTraceState_ShouldPreserveTraceState()
+        {
+            // Arrange - Create activity with parent context that has tracestate
+            var parentTraceId = ActivityTraceId.CreateRandom();
+            var parentSpanId = ActivitySpanId.CreateRandom();
+            var parentContext = new ActivityContext(parentTraceId, parentSpanId, ActivityTraceFlags.Recorded, "vendor1=value1");
+            
+            using var originalActivity = _activitySource.StartActivity("test-activity", ActivityKind.Internal, parentContext);
+            
+            var headers = new Dictionary<string, object>();
+
+            // Act - Inject
+            TraceContextPropagation.InjectTraceContext(headers, originalActivity);
+            
+            // Act - Extract
+            var extractedContext = TraceContextPropagation.ExtractTraceContext(headers);
+
+            // Assert
+            extractedContext.TraceId.Should().Be(originalActivity.TraceId);
+            extractedContext.SpanId.Should().Be(originalActivity.SpanId);
+            extractedContext.TraceFlags.Should().Be(originalActivity.ActivityTraceFlags);
+            // TraceState should be preserved if it was set
+            if (!string.IsNullOrEmpty(originalActivity.TraceStateString))
+            {
+                extractedContext.TraceState.Should().Be(originalActivity.TraceStateString);
+            }
+        }
+
+        [Fact]
+        public void ExtractTraceContext_WithNullTraceState_ShouldNotIncludeTraceState()
+        {
+            // Arrange
+            var headers = new Dictionary<string, object>
+            {
+                { "traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01" },
+                { "tracestate", null }
+            };
+
+            // Act
+            var context = TraceContextPropagation.ExtractTraceContext(headers);
+
+            // Assert
+            context.Should().NotBe(default(ActivityContext));
+            context.TraceState.Should().BeNull();
+        }
+
+        [Fact]
+        public void ExtractTraceContext_WithEmptyTraceState_ShouldIncludeEmptyTraceState()
+        {
+            // Arrange
+            var headers = new Dictionary<string, object>
+            {
+                { "traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01" },
+                { "tracestate", "" }
+            };
+
+            // Act
+            var context = TraceContextPropagation.ExtractTraceContext(headers);
+
+            // Assert
+            context.Should().NotBe(default(ActivityContext));
+            context.TraceState.Should().Be("");
+        }
+
+        // Helper class for testing ToString conversion
+        private class TraceParentWrapper
+        {
+            private readonly string _value;
+            
+            public TraceParentWrapper(string value)
+            {
+                _value = value;
+            }
+
+            public override string ToString()
+            {
+                return _value;
+            }
+        }
+    }
+}

--- a/src/tests/MessageWorkerPool.Test/Telemetry/NoOpTelemetryProviderTests.cs
+++ b/src/tests/MessageWorkerPool.Test/Telemetry/NoOpTelemetryProviderTests.cs
@@ -1,0 +1,344 @@
+using FluentAssertions;
+using MessageWorkerPool.Telemetry;
+using MessageWorkerPool.Telemetry.Abstractions;
+using MessageWorkerPool.Utilities;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace MessageWorkerPool.Test.Telemetry
+{
+    public class NoOpTelemetryProviderTests
+    {
+        [Fact]
+        public void Instance_ShouldReturnSingletonInstance()
+        {
+            // Act
+            var instance1 = NoOpTelemetryProvider.Instance;
+            var instance2 = NoOpTelemetryProvider.Instance;
+
+            // Assert
+            instance1.Should().BeSameAs(instance2);
+        }
+
+        [Fact]
+        public void StartActivity_ShouldReturnNoOpActivity()
+        {
+            // Arrange
+            var provider = NoOpTelemetryProvider.Instance;
+
+            // Act
+            var activity = provider.StartActivity("test-operation");
+
+            // Assert
+            activity.Should().NotBeNull();
+            activity.Should().BeOfType<NoOpActivity>();
+        }
+
+        [Fact]
+        public void StartActivity_WithTags_ShouldReturnNoOpActivity()
+        {
+            // Arrange
+            var provider = NoOpTelemetryProvider.Instance;
+            var tags = new Dictionary<string, object> { { "key", "value" } };
+
+            // Act
+            var activity = provider.StartActivity("test-operation", tags);
+
+            // Assert
+            activity.Should().NotBeNull();
+            activity.Should().BeOfType<NoOpActivity>();
+        }
+
+        [Fact]
+        public void Metrics_ShouldReturnNoOpMetrics()
+        {
+            // Arrange
+            var provider = NoOpTelemetryProvider.Instance;
+
+            // Act
+            var metrics = provider.Metrics;
+
+            // Assert
+            metrics.Should().NotBeNull();
+            metrics.Should().BeOfType<NoOpMetrics>();
+        }
+
+        [Fact]
+        public void Metrics_ShouldReturnSameSingletonInstance()
+        {
+            // Arrange
+            var provider = NoOpTelemetryProvider.Instance;
+
+            // Act
+            var metrics1 = provider.Metrics;
+            var metrics2 = provider.Metrics;
+
+            // Assert
+            metrics1.Should().BeSameAs(metrics2);
+        }
+    }
+
+    public class NoOpActivityTests
+    {
+        [Fact]
+        public void Instance_ShouldReturnSingletonInstance()
+        {
+            // Act
+            var instance1 = NoOpActivity.Instance;
+            var instance2 = NoOpActivity.Instance;
+
+            // Assert
+            instance1.Should().BeSameAs(instance2);
+        }
+
+        [Fact]
+        public void SetTag_ShouldNotThrow()
+        {
+            // Arrange
+            var activity = NoOpActivity.Instance;
+
+            // Act
+            Action act = () => activity.SetTag("key", "value");
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void SetTags_ShouldNotThrow()
+        {
+            // Arrange
+            var activity = NoOpActivity.Instance;
+            var tags = new Dictionary<string, object> { { "key1", "value1" }, { "key2", "value2" } };
+
+            // Act
+            Action act = () => activity.SetTags(tags);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void SetStatus_ShouldNotThrow()
+        {
+            // Arrange
+            var activity = NoOpActivity.Instance;
+
+            // Act
+            Action act = () => activity.SetStatus(ActivityStatus.Ok, "description");
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void RecordException_ShouldNotThrow()
+        {
+            // Arrange
+            var activity = NoOpActivity.Instance;
+            var exception = new InvalidOperationException("test");
+
+            // Act
+            Action act = () => activity.RecordException(exception);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Dispose_ShouldNotThrow()
+        {
+            // Arrange
+            var activity = NoOpActivity.Instance;
+
+            // Act
+            Action act = () => activity.Dispose();
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Dispose_CalledMultipleTimes_ShouldNotThrow()
+        {
+            // Arrange
+            var activity = NoOpActivity.Instance;
+
+            // Act
+            Action act = () =>
+            {
+                activity.Dispose();
+                activity.Dispose();
+                activity.Dispose();
+            };
+
+            // Assert
+            act.Should().NotThrow();
+        }
+    }
+
+    public class NoOpMetricsTests
+    {
+        [Fact]
+        public void Instance_ShouldReturnSingletonInstance()
+        {
+            // Act
+            var instance1 = NoOpMetrics.Instance;
+            var instance2 = NoOpMetrics.Instance;
+
+            // Assert
+            instance1.Should().BeSameAs(instance2);
+        }
+
+        [Fact]
+        public void RecordTaskProcessed_ShouldNotThrow()
+        {
+            // Arrange
+            var metrics = NoOpMetrics.Instance;
+
+            // Act
+            Action act = () => metrics.RecordTaskProcessed("queue", "worker");
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void RecordTaskFailed_ShouldNotThrow()
+        {
+            // Arrange
+            var metrics = NoOpMetrics.Instance;
+
+            // Act
+            Action act = () => metrics.RecordTaskFailed("queue", "worker", "ErrorType");
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void RecordTaskRejected_ShouldNotThrow()
+        {
+            // Arrange
+            var metrics = NoOpMetrics.Instance;
+
+            // Act
+            Action act = () => metrics.RecordTaskRejected("queue", "worker");
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void RecordTaskDuration_ShouldNotThrow()
+        {
+            // Arrange
+            var metrics = NoOpMetrics.Instance;
+
+            // Act
+            Action act = () => metrics.RecordTaskDuration(123.45, "queue", "worker");
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void SetActiveWorkers_ShouldNotThrow()
+        {
+            // Arrange
+            var metrics = NoOpMetrics.Instance;
+
+            // Act
+            Action act = () => metrics.SetActiveWorkers(5);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void SetProcessingTasks_ShouldNotThrow()
+        {
+            // Arrange
+            var metrics = NoOpMetrics.Instance;
+
+            // Act
+            Action act = () => metrics.SetProcessingTasks(10);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void SetHealthyWorkers_ShouldNotThrow()
+        {
+            // Arrange
+            var metrics = NoOpMetrics.Instance;
+
+            // Act
+            Action act = () => metrics.SetHealthyWorkers(3);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void SetStoppedWorkers_ShouldNotThrow()
+        {
+            // Arrange
+            var metrics = NoOpMetrics.Instance;
+
+            // Act
+            Action act = () => metrics.SetStoppedWorkers(2);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void IncrementProcessingTasks_ShouldNotThrow()
+        {
+            // Arrange
+            var metrics = NoOpMetrics.Instance;
+
+            // Act
+            Action act = () => metrics.IncrementProcessingTasks();
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void DecrementProcessingTasks_ShouldNotThrow()
+        {
+            // Arrange
+            var metrics = NoOpMetrics.Instance;
+
+            // Act
+            Action act = () => metrics.DecrementProcessingTasks();
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void AllMethods_WithNullParameters_ShouldNotThrow()
+        {
+            // Arrange
+            var metrics = NoOpMetrics.Instance;
+
+            // Act & Assert
+            Action act = () =>
+            {
+                metrics.RecordTaskProcessed(null, null);
+                metrics.RecordTaskFailed(null, null, null);
+                metrics.RecordTaskRejected(null, null);
+                metrics.RecordTaskDuration(0, null, null);
+            };
+
+            act.Should().NotThrow();
+        }
+    }
+}

--- a/src/tests/MessageWorkerPool.Test/Telemetry/TaskProcessingTelemetryTests.cs
+++ b/src/tests/MessageWorkerPool.Test/Telemetry/TaskProcessingTelemetryTests.cs
@@ -1,0 +1,305 @@
+using FluentAssertions;
+using MessageWorkerPool.Telemetry;
+using MessageWorkerPool.Telemetry.Abstractions;
+using MessageWorkerPool.Utilities;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MessageWorkerPool.Test.Telemetry
+{
+    [Collection("TelemetryTests")]
+    public class TaskProcessingTelemetryTests : IDisposable
+    {
+        private readonly Mock<ILogger> _mockLogger;
+        private readonly Mock<ITelemetryProvider> _mockProvider;
+        private readonly Mock<IActivity> _mockActivity;
+        private readonly Mock<IMetrics> _mockMetrics;
+
+        public TaskProcessingTelemetryTests()
+        {
+            _mockLogger = new Mock<ILogger>();
+            _mockProvider = new Mock<ITelemetryProvider>();
+            _mockActivity = new Mock<IActivity>();
+            _mockMetrics = new Mock<IMetrics>();
+
+            _mockProvider.Setup(p => p.StartActivity(It.IsAny<string>(), It.IsAny<IDictionary<string, object>>(), It.IsAny<ActivityKind>(), It.IsAny<ActivityContext>()))
+                .Returns(_mockActivity.Object);
+            _mockProvider.Setup(p => p.Metrics).Returns(_mockMetrics.Object);
+            
+            TelemetryManager.SetProvider(_mockProvider.Object);
+        }
+
+        public void Dispose()
+        {
+            // Clean up - reset to NoOp provider after each test
+            TelemetryManager.SetProvider(NoOpTelemetryProvider.Instance);
+        }
+
+        [Fact]
+        public void Constructor_ShouldStartStopwatchAndActivity()
+        {
+            // Arrange & Act
+            using var telemetry = new TaskProcessingTelemetry("worker-1", "test-queue", "corr-123", _mockLogger.Object);
+
+            // Assert
+            _mockProvider.Verify(p => p.StartActivity("Worker.ProcessTask", It.IsAny<IDictionary<string, object>>(), It.IsAny<ActivityKind>(), It.IsAny<ActivityContext>()), Times.Once);
+            _mockMetrics.Verify(m => m.IncrementProcessingTasks(), Times.Once);
+        }
+
+        [Fact]
+        public void Constructor_ShouldSetActivityTags()
+        {
+            // Arrange & Act
+            using var telemetry = new TaskProcessingTelemetry("worker-1", "test-queue", "corr-123", _mockLogger.Object);
+
+            // Assert
+            _mockActivity.Verify(a => a.SetTag("worker.id", "worker-1"), Times.Once);
+            _mockActivity.Verify(a => a.SetTag("queue.name", "test-queue"), Times.Once);
+            _mockActivity.Verify(a => a.SetTag("correlation.id", "corr-123"), Times.Once);
+            _mockActivity.Verify(a => a.SetTag("messaging.system", "rabbitmq"), Times.Once);
+            _mockActivity.Verify(a => a.SetTag("messaging.destination", "test-queue"), Times.Once);
+        }
+
+        [Fact]
+        public void SetTag_ShouldDelegateToActivity()
+        {
+            // Arrange
+            using var telemetry = new TaskProcessingTelemetry("worker-1", "test-queue", "corr-123", _mockLogger.Object);
+
+            // Act
+            telemetry.SetTag("custom.tag", "custom.value");
+
+            // Assert
+            _mockActivity.Verify(a => a.SetTag("custom.tag", "custom.value"), Times.Once);
+        }
+
+        [Fact]
+        public void RecordSuccess_ShouldRecordMetricsAndSetStatus()
+        {
+            // Arrange
+            using var telemetry = new TaskProcessingTelemetry("worker-1", "test-queue", "corr-123", _mockLogger.Object);
+
+            // Act
+            telemetry.RecordSuccess(MessageStatus.MESSAGE_DONE);
+
+            // Assert
+            _mockMetrics.Verify(m => m.RecordTaskProcessed("test-queue", "worker-1"), Times.Once);
+            _mockMetrics.Verify(m => m.RecordTaskDuration(It.IsAny<double>(), "test-queue", "worker-1"), Times.Once);
+            _mockActivity.Verify(a => a.SetTag("message.status", "MESSAGE_DONE"), Times.Once);
+            _mockActivity.Verify(a => a.SetStatus(ActivityStatus.Ok, null), Times.Once);
+        }
+
+        [Fact]
+        public void RecordSuccess_WithMessageDoneWithReply_ShouldSetCorrectStatus()
+        {
+            // Arrange
+            using var telemetry = new TaskProcessingTelemetry("worker-1", "test-queue", "corr-123", _mockLogger.Object);
+
+            // Act
+            telemetry.RecordSuccess(MessageStatus.MESSAGE_DONE_WITH_REPLY);
+
+            // Assert
+            _mockMetrics.Verify(m => m.RecordTaskProcessed("test-queue", "worker-1"), Times.Once);
+            _mockActivity.Verify(a => a.SetTag("message.status", "MESSAGE_DONE_WITH_REPLY"), Times.Once);
+            _mockActivity.Verify(a => a.SetStatus(ActivityStatus.Ok, null), Times.Once);
+        }
+
+        [Fact]
+        public void RecordSuccess_CalledMultipleTimes_ShouldOnlyRecordOnce()
+        {
+            // Arrange
+            using var telemetry = new TaskProcessingTelemetry("worker-1", "test-queue", "corr-123", _mockLogger.Object);
+
+            // Act
+            telemetry.RecordSuccess(MessageStatus.MESSAGE_DONE);
+            telemetry.RecordSuccess(MessageStatus.MESSAGE_DONE);
+            telemetry.RecordSuccess(MessageStatus.MESSAGE_DONE);
+
+            // Assert
+            _mockMetrics.Verify(m => m.RecordTaskProcessed(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public void RecordRejection_ShouldRecordMetricsAndSetStatus()
+        {
+            // Arrange
+            using var telemetry = new TaskProcessingTelemetry("worker-1", "test-queue", "corr-123", _mockLogger.Object);
+
+            // Act
+            telemetry.RecordRejection(MessageStatus.IGNORE_MESSAGE);
+
+            // Assert
+            _mockMetrics.Verify(m => m.RecordTaskRejected("test-queue", "worker-1"), Times.Once);
+            _mockMetrics.Verify(m => m.RecordTaskDuration(It.IsAny<double>(), "test-queue", "worker-1"), Times.Once);
+            _mockActivity.Verify(a => a.SetTag("message.status", "IGNORE_MESSAGE"), Times.Once);
+            _mockActivity.Verify(a => a.SetStatus(ActivityStatus.Error, "Message ignored"), Times.Once);
+        }
+
+        [Fact]
+        public void RecordRejection_CalledMultipleTimes_ShouldOnlyRecordOnce()
+        {
+            // Arrange
+            using var telemetry = new TaskProcessingTelemetry("worker-1", "test-queue", "corr-123", _mockLogger.Object);
+
+            // Act
+            telemetry.RecordRejection(MessageStatus.IGNORE_MESSAGE);
+            telemetry.RecordRejection(MessageStatus.IGNORE_MESSAGE);
+
+            // Assert
+            _mockMetrics.Verify(m => m.RecordTaskRejected(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public void RecordFailure_ShouldRecordMetricsAndException()
+        {
+            // Arrange
+            using var telemetry = new TaskProcessingTelemetry("worker-1", "test-queue", "corr-123", _mockLogger.Object);
+            var exception = new InvalidOperationException("Test exception");
+
+            // Act
+            telemetry.RecordFailure(exception);
+
+            // Assert
+            _mockMetrics.Verify(m => m.RecordTaskFailed("test-queue", "worker-1", "InvalidOperationException"), Times.Once);
+            _mockMetrics.Verify(m => m.RecordTaskDuration(It.IsAny<double>(), "test-queue", "worker-1"), Times.Once);
+            _mockActivity.Verify(a => a.SetStatus(ActivityStatus.Error, "Test exception"), Times.Once);
+            _mockActivity.Verify(a => a.RecordException(exception), Times.Once);
+        }
+
+        [Fact]
+        public void RecordFailure_ShouldLogWarning()
+        {
+            // Arrange
+            using var telemetry = new TaskProcessingTelemetry("worker-1", "test-queue", "corr-123", _mockLogger.Object);
+            var exception = new InvalidOperationException("Test exception");
+
+            // Act
+            telemetry.RecordFailure(exception);
+
+            // Assert
+            _mockLogger.Verify(x => x.Log(LogLevel.Warning, It.IsAny<EventId>(), It.Is<It.IsAnyType>((v, t) => true), exception, It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Once);
+        }
+
+        [Fact]
+        public void RecordFailure_CalledMultipleTimes_ShouldOnlyRecordOnce()
+        {
+            // Arrange
+            using var telemetry = new TaskProcessingTelemetry("worker-1", "test-queue", "corr-123", _mockLogger.Object);
+            var exception = new InvalidOperationException("Test exception");
+
+            // Act
+            telemetry.RecordFailure(exception);
+            telemetry.RecordFailure(exception);
+
+            // Assert
+            _mockMetrics.Verify(m => m.RecordTaskFailed(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public void Dispose_ShouldDecrementProcessingTasksAndDisposeActivity()
+        {
+            // Arrange
+            var telemetry = new TaskProcessingTelemetry("worker-1", "test-queue", "corr-123", _mockLogger.Object);
+
+            // Act
+            telemetry.Dispose();
+
+            // Assert
+            _mockMetrics.Verify(m => m.DecrementProcessingTasks(), Times.Once);
+            _mockActivity.Verify(a => a.Dispose(), Times.Once);
+        }
+
+        [Fact]
+        public void Dispose_CalledMultipleTimes_ShouldOnlyExecuteOnce()
+        {
+            // Arrange
+            var telemetry = new TaskProcessingTelemetry("worker-1", "test-queue", "corr-123", _mockLogger.Object);
+
+            // Act
+            telemetry.Dispose();
+            telemetry.Dispose();
+            telemetry.Dispose();
+
+            // Assert
+            _mockMetrics.Verify(m => m.DecrementProcessingTasks(), Times.Once);
+            _mockActivity.Verify(a => a.Dispose(), Times.Once);
+        }
+
+        [Fact]
+        public void RecordSuccess_AfterRecordFailure_ShouldNotRecord()
+        {
+            // Arrange
+            using var telemetry = new TaskProcessingTelemetry("worker-1", "test-queue", "corr-123", _mockLogger.Object);
+            var exception = new InvalidOperationException("Test exception");
+
+            // Act
+            telemetry.RecordFailure(exception);
+            telemetry.RecordSuccess(MessageStatus.MESSAGE_DONE);
+
+            // Assert
+            _mockMetrics.Verify(m => m.RecordTaskFailed(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+            _mockMetrics.Verify(m => m.RecordTaskProcessed(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public void RecordRejection_AfterRecordSuccess_ShouldNotRecord()
+        {
+            // Arrange
+            using var telemetry = new TaskProcessingTelemetry("worker-1", "test-queue", "corr-123", _mockLogger.Object);
+
+            // Act
+            telemetry.RecordSuccess(MessageStatus.MESSAGE_DONE);
+            telemetry.RecordRejection(MessageStatus.IGNORE_MESSAGE);
+
+            // Assert
+            _mockMetrics.Verify(m => m.RecordTaskProcessed(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+            _mockMetrics.Verify(m => m.RecordTaskRejected(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public void RecordTaskDuration_ShouldBeMeasuredAccurately()
+        {
+            // Arrange
+            using var telemetry = new TaskProcessingTelemetry("worker-1", "test-queue", "corr-123", _mockLogger.Object);
+            
+            // Act - Simulate some processing time
+            System.Threading.Thread.Sleep(100);
+            telemetry.RecordSuccess(MessageStatus.MESSAGE_DONE);
+
+            // Assert - Duration should be at least 100ms (allowing for some variance)
+            _mockMetrics.Verify(m => m.RecordTaskDuration(It.Is<double>(d => d >= 90), "test-queue", "worker-1"), Times.Once);
+        }
+
+        [Fact]
+        public void Constructor_WithNullLogger_ShouldNotThrow()
+        {
+            // Arrange & Act
+            Action act = () =>
+            {
+                using var telemetry = new TaskProcessingTelemetry("worker-1", "test-queue", "corr-123", null);
+            };
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void RecordFailure_WithNullLogger_ShouldNotThrow()
+        {
+            // Arrange
+            using var telemetry = new TaskProcessingTelemetry("worker-1", "test-queue", "corr-123", null);
+            var exception = new InvalidOperationException("Test exception");
+
+            // Act
+            Action act = () => telemetry.RecordFailure(exception);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+    }
+}

--- a/src/tests/MessageWorkerPool.Test/Telemetry/TaskProcessingTelemetryTests.cs
+++ b/src/tests/MessageWorkerPool.Test/Telemetry/TaskProcessingTelemetryTests.cs
@@ -230,7 +230,7 @@ namespace MessageWorkerPool.Test.Telemetry
             _mockMetrics.Verify(m => m.RecordTaskRejected("test-queue", "worker-1"), Times.Once);
             _mockMetrics.Verify(m => m.RecordTaskDuration(It.IsAny<double>(), "test-queue", "worker-1"), Times.Once);
             _mockActivity.Verify(a => a.SetTag("message.status", "IGNORE_MESSAGE"), Times.Once);
-            _mockActivity.Verify(a => a.SetStatus(ActivityStatus.Error, "Message ignored"), Times.Once);
+            _mockActivity.Verify(a => a.SetStatus(ActivityStatus.Ok, null));
         }
 
         [Fact]

--- a/src/tests/MessageWorkerPool.Test/Telemetry/TelemetryManagerTests.cs
+++ b/src/tests/MessageWorkerPool.Test/Telemetry/TelemetryManagerTests.cs
@@ -368,7 +368,7 @@ namespace MessageWorkerPool.Test.Telemetry
 
             // Assert
             mockActivity.Verify(a => a.SetTag("message.status", "IGNORE_MESSAGE"), Times.Once);
-            mockActivity.Verify(a => a.SetStatus(ActivityStatus.Error, "Message ignored"), Times.Once);
+            mockActivity.Verify(a => a.SetStatus(ActivityStatus.Ok, null), Times.Once);
         }
 
         [Fact]

--- a/src/tests/MessageWorkerPool.Test/Telemetry/TelemetryManagerTests.cs
+++ b/src/tests/MessageWorkerPool.Test/Telemetry/TelemetryManagerTests.cs
@@ -1,0 +1,279 @@
+using FluentAssertions;
+using MessageWorkerPool.Telemetry;
+using MessageWorkerPool.Telemetry.Abstractions;
+using MessageWorkerPool.Utilities;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Xunit;
+
+namespace MessageWorkerPool.Test.Telemetry
+{
+    [Collection("TelemetryTests")]
+    public class TelemetryManagerTests : IDisposable
+    {
+        public void Dispose()
+        {
+            // Clean up - reset to NoOp provider after each test
+            TelemetryManager.SetProvider(NoOpTelemetryProvider.Instance);
+        }
+
+        [Fact]
+        public void SetProvider_WithValidProvider_ShouldSetProvider()
+        {
+            // Arrange
+            var mockProvider = new Mock<ITelemetryProvider>();
+
+            // Act
+            TelemetryManager.SetProvider(mockProvider.Object);
+
+            // Assert
+            TelemetryManager.Provider.Should().Be(mockProvider.Object);
+        }
+
+        [Fact]
+        public void SetProvider_WithNull_ShouldThrowArgumentNullException()
+        {
+            // Act
+            Action act = () => TelemetryManager.SetProvider(null);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>().WithParameterName("provider");
+        }
+
+        [Fact]
+        public void Provider_ByDefault_ShouldReturnNoOpProvider()
+        {
+            // Arrange - Reset to default
+            TelemetryManager.SetProvider(NoOpTelemetryProvider.Instance);
+
+            // Act
+            var provider = TelemetryManager.Provider;
+
+            // Assert
+            provider.Should().BeOfType<NoOpTelemetryProvider>();
+        }
+
+        [Fact]
+        public void StartWorkerInitActivity_ShouldCreateActivityWithCorrectTags()
+        {
+            // Arrange
+            var mockActivity = new Mock<IActivity>();
+            var mockProvider = new Mock<ITelemetryProvider>();
+            mockProvider.Setup(p => p.StartActivity("Worker.Init", It.IsAny<IDictionary<string, object>>(), It.IsAny<ActivityKind>(), It.IsAny<ActivityContext>())).Returns(mockActivity.Object);
+            TelemetryManager.SetProvider(mockProvider.Object);
+
+            // Act
+            var activity = TelemetryManager.StartWorkerInitActivity("worker-1", "test-queue");
+
+            // Assert
+            activity.Should().Be(mockActivity.Object);
+            mockProvider.Verify(p => p.StartActivity("Worker.Init", It.IsAny<IDictionary<string, object>>(), It.IsAny<ActivityKind>(), It.IsAny<ActivityContext>()), Times.Once);
+            mockActivity.Verify(a => a.SetTag("worker.id", "worker-1"), Times.Once);
+            mockActivity.Verify(a => a.SetTag("queue.name", "test-queue"), Times.Once);
+        }
+
+        [Fact]
+        public void StartTaskProcessingActivity_ShouldCreateActivityWithCorrectTags()
+        {
+            // Arrange
+            var mockActivity = new Mock<IActivity>();
+            var mockProvider = new Mock<ITelemetryProvider>();
+            mockProvider.Setup(p => p.StartActivity("Worker.ProcessTask", It.IsAny<IDictionary<string, object>>(), It.IsAny<ActivityKind>(), It.IsAny<ActivityContext>())).Returns(mockActivity.Object);
+            TelemetryManager.SetProvider(mockProvider.Object);
+
+            // Act
+            var activity = TelemetryManager.StartTaskProcessingActivity("worker-1", "test-queue", "corr-123");
+
+            // Assert
+            activity.Should().Be(mockActivity.Object);
+            mockProvider.Verify(p => p.StartActivity("Worker.ProcessTask", It.IsAny<IDictionary<string, object>>(), It.IsAny<ActivityKind>(), It.IsAny<ActivityContext>()), Times.Once);
+            mockActivity.Verify(a => a.SetTag("worker.id", "worker-1"), Times.Once);
+            mockActivity.Verify(a => a.SetTag("queue.name", "test-queue"), Times.Once);
+            mockActivity.Verify(a => a.SetTag("correlation.id", "corr-123"), Times.Once);
+            mockActivity.Verify(a => a.SetTag("messaging.system", "rabbitmq"), Times.Once);
+            mockActivity.Verify(a => a.SetTag("messaging.destination", "test-queue"), Times.Once);
+        }
+
+        [Fact]
+        public void StartPoolInitActivity_ShouldCreateActivityWithCorrectTags()
+        {
+            // Arrange
+            var mockActivity = new Mock<IActivity>();
+            var mockProvider = new Mock<ITelemetryProvider>();
+            mockProvider.Setup(p => p.StartActivity("WorkerPool.Init", It.IsAny<IDictionary<string, object>>(), It.IsAny<ActivityKind>(), It.IsAny<ActivityContext>())).Returns(mockActivity.Object);
+            TelemetryManager.SetProvider(mockProvider.Object);
+
+            // Act
+            var activity = TelemetryManager.StartPoolInitActivity(5, "test-queue");
+
+            // Assert
+            activity.Should().Be(mockActivity.Object);
+            mockProvider.Verify(p => p.StartActivity("WorkerPool.Init", It.IsAny<IDictionary<string, object>>(), It.IsAny<ActivityKind>(), It.IsAny<ActivityContext>()), Times.Once);
+            mockActivity.Verify(a => a.SetTag("workerpool.worker_count", 5), Times.Once);
+            mockActivity.Verify(a => a.SetTag("queue.name", "test-queue"), Times.Once);
+        }
+
+        [Fact]
+        public void StartShutdownActivity_ShouldCreateActivityWithCorrectTags()
+        {
+            // Arrange
+            var mockActivity = new Mock<IActivity>();
+            var mockProvider = new Mock<ITelemetryProvider>();
+            mockProvider.Setup(p => p.StartActivity("Worker.Shutdown", It.IsAny<IDictionary<string, object>>(), It.IsAny<ActivityKind>(), It.IsAny<ActivityContext>())).Returns(mockActivity.Object);
+            TelemetryManager.SetProvider(mockProvider.Object);
+
+            // Act
+            var activity = TelemetryManager.StartShutdownActivity("worker-1");
+
+            // Assert
+            activity.Should().Be(mockActivity.Object);
+            mockProvider.Verify(p => p.StartActivity("Worker.Shutdown", It.IsAny<IDictionary<string, object>>(), It.IsAny<ActivityKind>(), It.IsAny<ActivityContext>()), Times.Once);
+            mockActivity.Verify(a => a.SetTag("worker.id", "worker-1"), Times.Once);
+        }
+
+        [Fact]
+        public void RecordException_WithValidActivityAndException_ShouldRecordException()
+        {
+            // Arrange
+            var mockActivity = new Mock<IActivity>();
+            var exception = new InvalidOperationException("Test exception");
+
+            // Act
+            TelemetryManager.RecordException(mockActivity.Object, exception);
+
+            // Assert
+            mockActivity.Verify(a => a.SetStatus(ActivityStatus.Error, "Test exception"), Times.Once);
+            mockActivity.Verify(a => a.RecordException(exception), Times.Once);
+        }
+
+        [Fact]
+        public void RecordException_WithNullActivity_ShouldNotThrow()
+        {
+            // Arrange
+            var exception = new InvalidOperationException("Test exception");
+
+            // Act
+            Action act = () => TelemetryManager.RecordException(null, exception);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void RecordException_WithNullException_ShouldNotThrow()
+        {
+            // Arrange
+            var mockActivity = new Mock<IActivity>();
+
+            // Act
+            Action act = () => TelemetryManager.RecordException(mockActivity.Object, null);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void SetTaskStatus_WithMessageDone_ShouldSetOkStatus()
+        {
+            // Arrange
+            var mockActivity = new Mock<IActivity>();
+
+            // Act
+            TelemetryManager.SetTaskStatus(mockActivity.Object, MessageStatus.MESSAGE_DONE);
+
+            // Assert
+            mockActivity.Verify(a => a.SetTag("message.status", "MESSAGE_DONE"), Times.Once);
+            mockActivity.Verify(a => a.SetStatus(ActivityStatus.Ok, null), Times.Once);
+        }
+
+        [Fact]
+        public void SetTaskStatus_WithMessageDoneWithReply_ShouldSetOkStatus()
+        {
+            // Arrange
+            var mockActivity = new Mock<IActivity>();
+
+            // Act
+            TelemetryManager.SetTaskStatus(mockActivity.Object, MessageStatus.MESSAGE_DONE_WITH_REPLY);
+
+            // Assert
+            mockActivity.Verify(a => a.SetTag("message.status", "MESSAGE_DONE_WITH_REPLY"), Times.Once);
+            mockActivity.Verify(a => a.SetStatus(ActivityStatus.Ok, null), Times.Once);
+        }
+
+        [Fact]
+        public void SetTaskStatus_WithIgnoreMessage_ShouldSetErrorStatus()
+        {
+            // Arrange
+            var mockActivity = new Mock<IActivity>();
+
+            // Act
+            TelemetryManager.SetTaskStatus(mockActivity.Object, MessageStatus.IGNORE_MESSAGE);
+
+            // Assert
+            mockActivity.Verify(a => a.SetTag("message.status", "IGNORE_MESSAGE"), Times.Once);
+            mockActivity.Verify(a => a.SetStatus(ActivityStatus.Error, "Message ignored"), Times.Once);
+        }
+
+        [Fact]
+        public void SetTaskStatus_WithNullActivity_ShouldNotThrow()
+        {
+            // Act
+            Action act = () => TelemetryManager.SetTaskStatus(null, MessageStatus.MESSAGE_DONE);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Metrics_ShouldReturnProviderMetrics()
+        {
+            // Arrange - Create fresh provider for this test
+            var mockMetrics = new Mock<IMetrics>();
+            var mockProvider = new Mock<ITelemetryProvider>();
+            mockProvider.Setup(p => p.Metrics).Returns(mockMetrics.Object);
+            
+            // Set provider and immediately get metrics
+            TelemetryManager.SetProvider(mockProvider.Object);
+
+            // Act
+            var metrics = TelemetryManager.Metrics;
+
+            // Assert
+            metrics.Should().Be(mockMetrics.Object);
+            
+            // Cleanup - restore original provider
+            TelemetryManager.SetProvider(NoOpTelemetryProvider.Instance);
+        }
+
+        [Fact]
+        public void StartWorkerInitActivity_WithNullProvider_ShouldReturnNull()
+        {
+            // Arrange
+            var mockProvider = new Mock<ITelemetryProvider>();
+            mockProvider.Setup(p => p.StartActivity("Worker.Init", It.IsAny<IDictionary<string, object>>(), It.IsAny<ActivityKind>(), It.IsAny<ActivityContext>())).Returns((IActivity)null);
+            TelemetryManager.SetProvider(mockProvider.Object);
+
+            // Act
+            var activity = TelemetryManager.StartWorkerInitActivity("worker-1", "test-queue");
+
+            // Assert
+            activity.Should().BeNull();
+        }
+
+        [Fact]
+        public void StartTaskProcessingActivity_WithNoOpProvider_ShouldReturnNoOpActivity()
+        {
+            // Arrange
+            TelemetryManager.SetProvider(NoOpTelemetryProvider.Instance);
+
+            // Act
+            var activity = TelemetryManager.StartTaskProcessingActivity("worker-1", "test-queue", "corr-123");
+
+            // Assert
+            activity.Should().NotBeNull();
+            activity.Should().BeOfType<NoOpActivity>();
+        }
+    }
+}

--- a/src/tests/MessageWorkerPool.Test/Telemetry/TelemetryTestsCollection.cs
+++ b/src/tests/MessageWorkerPool.Test/Telemetry/TelemetryTestsCollection.cs
@@ -1,0 +1,13 @@
+using Xunit;
+
+namespace MessageWorkerPool.Test.Telemetry
+{
+    /// <summary>
+    /// Collection definition to ensure telemetry tests run serially
+    /// since they share the static TelemetryManager.
+    /// </summary>
+    [CollectionDefinition("TelemetryTests", DisableParallelization = true)]
+    public class TelemetryTestsCollection
+    {
+    }
+}

--- a/src/tests/MessageWorkerPool.Test/Telemetry/WorkerPoolInformationTests.cs
+++ b/src/tests/MessageWorkerPool.Test/Telemetry/WorkerPoolInformationTests.cs
@@ -1,0 +1,413 @@
+using FluentAssertions;
+using MessageWorkerPool.Telemetry;
+using MessageWorkerPool.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using Moq;
+
+namespace MessageWorkerPool.Test.Telemetry
+{
+    public class WorkerPoolInformationTests
+    {
+        [Fact]
+        public void HealthPercentage_WithHealthyWorkers_ShouldCalculateCorrectly()
+        {
+            // Arrange
+            var info = new WorkerPoolInformation
+            {
+                TotalWorkers = 10,
+                HealthyWorkers = 8
+            };
+
+            // Act
+            var percentage = info.HealthPercentage;
+
+            // Assert
+            percentage.Should().Be(80.0);
+        }
+
+        [Fact]
+        public void HealthPercentage_WithNoTotalWorkers_ShouldReturnZero()
+        {
+            // Arrange
+            var info = new WorkerPoolInformation
+            {
+                TotalWorkers = 0,
+                HealthyWorkers = 0
+            };
+
+            // Act
+            var percentage = info.HealthPercentage;
+
+            // Assert
+            percentage.Should().Be(0);
+        }
+
+        [Fact]
+        public void HealthPercentage_WithAllHealthyWorkers_ShouldReturn100()
+        {
+            // Arrange
+            var info = new WorkerPoolInformation
+            {
+                TotalWorkers = 5,
+                HealthyWorkers = 5
+            };
+
+            // Act
+            var percentage = info.HealthPercentage;
+
+            // Assert
+            percentage.Should().Be(100.0);
+        }
+
+        [Fact]
+        public void HealthPercentage_WithNoHealthyWorkers_ShouldReturnZero()
+        {
+            // Arrange
+            var info = new WorkerPoolInformation
+            {
+                TotalWorkers = 5,
+                HealthyWorkers = 0
+            };
+
+            // Act
+            var percentage = info.HealthPercentage;
+
+            // Assert
+            percentage.Should().Be(0);
+        }
+
+        [Fact]
+        public void Constructor_ShouldInitializeWorkersListAsEmpty()
+        {
+            // Arrange & Act
+            var info = new WorkerPoolInformation();
+
+            // Assert
+            info.Workers.Should().NotBeNull();
+            info.Workers.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Properties_ShouldBeSettableAndGettable()
+        {
+            // Arrange
+            var createdAt = DateTime.UtcNow;
+            var info = new WorkerPoolInformation
+            {
+                PoolId = "pool-123",
+                QueueName = "test-queue",
+                TotalWorkers = 5,
+                HealthyWorkers = 4,
+                StoppedWorkers = 1,
+                StoppingWorkers = 0,
+                WaitingWorkers = 0,
+                CommandLine = "dotnet worker.dll",
+                CreatedAt = createdAt,
+                IsClosed = false
+            };
+
+            // Assert
+            info.PoolId.Should().Be("pool-123");
+            info.QueueName.Should().Be("test-queue");
+            info.TotalWorkers.Should().Be(5);
+            info.HealthyWorkers.Should().Be(4);
+            info.StoppedWorkers.Should().Be(1);
+            info.StoppingWorkers.Should().Be(0);
+            info.WaitingWorkers.Should().Be(0);
+            info.CommandLine.Should().Be("dotnet worker.dll");
+            info.CreatedAt.Should().Be(createdAt);
+            info.IsClosed.Should().BeFalse();
+        }
+    }
+
+    public class WorkerInformationTests
+    {
+        [Fact]
+        public void IsHealthy_WithRunningStatus_ShouldReturnTrue()
+        {
+            // Arrange
+            var info = new WorkerInformation
+            {
+                Status = WorkerStatus.Running
+            };
+
+            // Act & Assert
+            info.IsHealthy.Should().BeTrue();
+        }
+
+        [Fact]
+        public void IsHealthy_WithStoppedStatus_ShouldReturnFalse()
+        {
+            // Arrange
+            var info = new WorkerInformation
+            {
+                Status = WorkerStatus.Stopped
+            };
+
+            // Act & Assert
+            info.IsHealthy.Should().BeFalse();
+        }
+
+        [Fact]
+        public void IsHealthy_WithStoppingStatus_ShouldReturnFalse()
+        {
+            // Arrange
+            var info = new WorkerInformation
+            {
+                Status = WorkerStatus.Stopping
+            };
+
+            // Act & Assert
+            info.IsHealthy.Should().BeFalse();
+        }
+
+        [Fact]
+        public void IsHealthy_WithWaitForInitStatus_ShouldReturnFalse()
+        {
+            // Arrange
+            var info = new WorkerInformation
+            {
+                Status = WorkerStatus.WaitForInit
+            };
+
+            // Act & Assert
+            info.IsHealthy.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Properties_ShouldBeSettableAndGettable()
+        {
+            // Arrange
+            var createdAt = DateTime.UtcNow;
+            var lastActivityAt = DateTime.UtcNow.AddMinutes(-5);
+            var info = new WorkerInformation
+            {
+                WorkerId = "worker-1",
+                ProcessId = 12345,
+                Status = WorkerStatus.Running,
+                QueueName = "test-queue",
+                TasksProcessed = 100,
+                CurrentTaskCount = 2,
+                CreatedAt = createdAt,
+                LastActivityAt = lastActivityAt
+            };
+
+            // Assert
+            info.WorkerId.Should().Be("worker-1");
+            info.ProcessId.Should().Be(12345);
+            info.Status.Should().Be(WorkerStatus.Running);
+            info.QueueName.Should().Be("test-queue");
+            info.TasksProcessed.Should().Be(100);
+            info.CurrentTaskCount.Should().Be(2);
+            info.CreatedAt.Should().Be(createdAt);
+            info.LastActivityAt.Should().Be(lastActivityAt);
+        }
+    }
+
+    public class WorkerPoolInformationCollectorTests
+    {
+        [Fact]
+        public void CollectWorkerStatus_WithRunningWorkers_ShouldCountCorrectly()
+        {
+            // Arrange
+            var workers = new List<IWorker>
+            {
+                new TestWorker(WorkerStatus.Running),
+                new TestWorker(WorkerStatus.Running),
+                new TestWorker(WorkerStatus.Running)
+            };
+
+            // Act
+            var summary = WorkerPoolInformationCollector.CollectWorkerStatus(workers, "test-queue");
+
+            // Assert
+            summary.QueueName.Should().Be("test-queue");
+            summary.TotalWorkers.Should().Be(3);
+            summary.HealthyWorkers.Should().Be(3);
+            summary.StoppedWorkers.Should().Be(0);
+            summary.StoppingWorkers.Should().Be(0);
+            summary.WaitingWorkers.Should().Be(0);
+        }
+
+        [Fact]
+        public void CollectWorkerStatus_WithMixedStatuses_ShouldCountCorrectly()
+        {
+            // Arrange
+            var workers = new List<IWorker>
+            {
+                new TestWorker(WorkerStatus.Running),
+                new TestWorker(WorkerStatus.Running),
+                new TestWorker(WorkerStatus.Stopped),
+                new TestWorker(WorkerStatus.Stopping),
+                new TestWorker(WorkerStatus.WaitForInit)
+            };
+
+            // Act
+            var summary = WorkerPoolInformationCollector.CollectWorkerStatus(workers, "test-queue");
+
+            // Assert
+            summary.TotalWorkers.Should().Be(5);
+            summary.HealthyWorkers.Should().Be(2);
+            summary.StoppedWorkers.Should().Be(1);
+            summary.StoppingWorkers.Should().Be(1);
+            summary.WaitingWorkers.Should().Be(1);
+        }
+
+        [Fact]
+        public void CollectWorkerStatus_WithEmptyWorkerList_ShouldReturnZeroCounts()
+        {
+            // Arrange
+            var workers = new List<IWorker>();
+
+            // Act
+            var summary = WorkerPoolInformationCollector.CollectWorkerStatus(workers, "test-queue");
+
+            // Assert
+            summary.TotalWorkers.Should().Be(0);
+            summary.HealthyWorkers.Should().Be(0);
+            summary.StoppedWorkers.Should().Be(0);
+            summary.StoppingWorkers.Should().Be(0);
+            summary.WaitingWorkers.Should().Be(0);
+        }
+
+        [Fact]
+        public void CollectWorkerStatus_WithNonWorkerBaseInstances_ShouldNotCount()
+        {
+            // Arrange
+            var mockWorker = new Mock<IWorker>();
+            var workers = new List<IWorker> { mockWorker.Object };
+
+            // Act
+            var summary = WorkerPoolInformationCollector.CollectWorkerStatus(workers, "test-queue");
+
+            // Assert
+            summary.TotalWorkers.Should().Be(1);
+            summary.HealthyWorkers.Should().Be(0);
+            summary.StoppedWorkers.Should().Be(0);
+            summary.StoppingWorkers.Should().Be(0);
+            summary.WaitingWorkers.Should().Be(0);
+        }
+
+        [Fact]
+        public void CollectWorkerStatus_WithAllStoppedWorkers_ShouldCountCorrectly()
+        {
+            // Arrange
+            var workers = new List<IWorker>
+            {
+                new TestWorker(WorkerStatus.Stopped),
+                new TestWorker(WorkerStatus.Stopped),
+                new TestWorker(WorkerStatus.Stopped)
+            };
+
+            // Act
+            var summary = WorkerPoolInformationCollector.CollectWorkerStatus(workers, "test-queue");
+
+            // Assert
+            summary.TotalWorkers.Should().Be(3);
+            summary.HealthyWorkers.Should().Be(0);
+            summary.StoppedWorkers.Should().Be(3);
+            summary.StoppingWorkers.Should().Be(0);
+            summary.WaitingWorkers.Should().Be(0);
+        }
+
+        [Fact]
+        public void CollectWorkerStatus_WithAllWaitingWorkers_ShouldCountCorrectly()
+        {
+            // Arrange
+            var workers = new List<IWorker>
+            {
+                new TestWorker(WorkerStatus.WaitForInit),
+                new TestWorker(WorkerStatus.WaitForInit)
+            };
+
+            // Act
+            var summary = WorkerPoolInformationCollector.CollectWorkerStatus(workers, "test-queue");
+
+            // Assert
+            summary.TotalWorkers.Should().Be(2);
+            summary.HealthyWorkers.Should().Be(0);
+            summary.StoppedWorkers.Should().Be(0);
+            summary.StoppingWorkers.Should().Be(0);
+            summary.WaitingWorkers.Should().Be(2);
+        }
+
+        [Fact]
+        public void CollectWorkerStatus_WithDifferentQueueName_ShouldSetCorrectly()
+        {
+            // Arrange
+            var workers = new List<IWorker> { new TestWorker(WorkerStatus.Running) };
+
+            // Act
+            var summary = WorkerPoolInformationCollector.CollectWorkerStatus(workers, "my-queue");
+
+            // Assert
+            summary.QueueName.Should().Be("my-queue");
+        }
+
+        // Test helper class that extends WorkerBase and allows us to set status
+        private class TestWorker : WorkerBase
+        {
+            private readonly WorkerStatus _testStatus;
+
+            public TestWorker(WorkerStatus status) 
+                : base(new WorkerPoolSetting { QueueName = "test", CommandLine = "test" }, 
+                       Mock.Of<Microsoft.Extensions.Logging.ILogger<WorkerBase>>())
+            {
+                _testStatus = status;
+                // Use reflection to set the private _status field
+                var statusField = typeof(WorkerBase).GetField("_status", 
+                    System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                statusField?.SetValue(this, status);
+            }
+
+            protected override void SetupMessageQueueSetting(System.Threading.CancellationToken token)
+            {
+                // Not needed for tests
+            }
+        }
+    }
+
+    public class WorkerStatusSummaryTests
+    {
+        [Fact]
+        public void Properties_ShouldBeSettableAndGettable()
+        {
+            // Arrange & Act
+            var summary = new WorkerStatusSummary
+            {
+                QueueName = "test-queue",
+                TotalWorkers = 10,
+                HealthyWorkers = 8,
+                StoppedWorkers = 1,
+                StoppingWorkers = 1,
+                WaitingWorkers = 0
+            };
+
+            // Assert
+            summary.QueueName.Should().Be("test-queue");
+            summary.TotalWorkers.Should().Be(10);
+            summary.HealthyWorkers.Should().Be(8);
+            summary.StoppedWorkers.Should().Be(1);
+            summary.StoppingWorkers.Should().Be(1);
+            summary.WaitingWorkers.Should().Be(0);
+        }
+
+        [Fact]
+        public void DefaultConstructor_ShouldInitializeWithDefaultValues()
+        {
+            // Arrange & Act
+            var summary = new WorkerStatusSummary();
+
+            // Assert
+            summary.QueueName.Should().BeNull();
+            summary.TotalWorkers.Should().Be(0);
+            summary.HealthyWorkers.Should().Be(0);
+            summary.StoppedWorkers.Should().Be(0);
+            summary.StoppingWorkers.Should().Be(0);
+            summary.WaitingWorkers.Should().Be(0);
+        }
+    }
+}

--- a/src/tests/MessageWorkerPool.Test/WorkerPoolBaseTests.cs
+++ b/src/tests/MessageWorkerPool.Test/WorkerPoolBaseTests.cs
@@ -1,18 +1,30 @@
 using FluentAssertions;
 using MessageWorkerPool.Test.Utility;
+using MessageWorkerPool.Telemetry;
+using MessageWorkerPool.OpenTelemetry;
 using Microsoft.Extensions.Logging;
 using Moq;
+using System.Diagnostics;
 
 namespace MessageWorkerPool.Test
 {
 
     public class WorkerPoolBaseTests
     {
+        private Mock<ILoggerFactory> CreateMockLoggerFactory()
+        {
+            var mockLoggerFactory = new Mock<ILoggerFactory>();
+            var mockLogger = new Mock<ILogger<WorkerPoolBase>>();
+            mockLoggerFactory.Setup(x => x.CreateLogger(It.IsAny<string>()))
+                .Returns(mockLogger.Object);
+            return mockLoggerFactory;
+        }
+
         [Fact]
         public async Task InitPoolAsync_ShouldInitializeCorrectNumberOfWorkers()
         {
             // Arrange
-            var mockLoggerFactory = new Mock<ILoggerFactory>();
+            var mockLoggerFactory = CreateMockLoggerFactory();
             var mockWorkerSetting = new WorkerPoolSetting { WorkerUnitCount = 3 };
             var workerPool = new TestWorkerPool(mockWorkerSetting, mockLoggerFactory.Object);
 
@@ -27,7 +39,7 @@ namespace MessageWorkerPool.Test
         public async Task WaitFinishedAsync_ShouldWaitForWorkersToFinishAndDispose()
         {
             // Arrange
-            var mockLoggerFactory = new Mock<ILoggerFactory>();
+            var mockLoggerFactory = CreateMockLoggerFactory();
             var mockWorkerSetting = new WorkerPoolSetting { WorkerUnitCount = 2 };
             var workerPool = new TestWorkerPool(mockWorkerSetting, mockLoggerFactory.Object);
             await workerPool.InitPoolAsync(CancellationToken.None);
@@ -44,7 +56,7 @@ namespace MessageWorkerPool.Test
         public void Dispose_ShouldDisposeWorkers()
         {
             // Arrange
-            var mockLoggerFactory = new Mock<ILoggerFactory>();
+            var mockLoggerFactory = CreateMockLoggerFactory();
             var mockWorkerSetting = new WorkerPoolSetting { WorkerUnitCount = 2 };
             var workerPool = new TestWorkerPool(mockWorkerSetting, mockLoggerFactory.Object);
             var mockWorker1 = new Mock<IWorker>();
@@ -59,6 +71,282 @@ namespace MessageWorkerPool.Test
             mockWorker1.Verify(w => w.Dispose(), Times.Once);  // Worker 1 should be disposed
             mockWorker2.Verify(w => w.Dispose(), Times.Once);  // Worker 2 should be disposed
             workerPool.IsClosed.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Constructor_ShouldInitializeWithoutError()
+        {
+            // Arrange
+            var mockLoggerFactory = CreateMockLoggerFactory();
+            var mockWorkerSetting = new WorkerPoolSetting { WorkerUnitCount = 2, QueueName = "test-queue" };
+
+            // Act
+            var workerPool = new TestWorkerPool(mockWorkerSetting, mockLoggerFactory.Object);
+
+            // Assert - Constructor should complete successfully
+            workerPool.Should().NotBeNull();
+            workerPool.ProcessCount.Should().Be(2);
+        }
+
+        [Fact]
+        public async Task InitPoolAsync_ShouldSetActiveWorkersMetric()
+        {
+            // Arrange
+            var mockLoggerFactory = CreateMockLoggerFactory();
+            var mockWorkerSetting = new WorkerPoolSetting { WorkerUnitCount = 3, QueueName = "test-queue" };
+            var workerPool = new TestWorkerPool(mockWorkerSetting, mockLoggerFactory.Object);
+
+            // Act
+            await workerPool.InitPoolAsync(CancellationToken.None);
+
+            // Assert - The metrics should be set to the number of workers
+            // Note: We can't directly assert on internal metrics state, but we can verify the pool initialized correctly
+            workerPool.ProcessCount.Should().Be(3);
+        }
+
+        [Fact]
+        public async Task InitPoolAsync_ShouldCreateActivityWithCorrectTags()
+        {
+            // Arrange
+            // Set up OpenTelemetry provider for the test
+            var openTelemetryProvider = new OpenTelemetryProvider("MessageWorkerPool", "1.0.0");
+            TelemetryManager.SetProvider(openTelemetryProvider);
+
+            var mockLoggerFactory = CreateMockLoggerFactory();
+            var mockWorkerSetting = new WorkerPoolSetting { WorkerUnitCount = 2, QueueName = "test-queue" };
+            var workerPool = new TestWorkerPool(mockWorkerSetting, mockLoggerFactory.Object);
+
+            var activities = new List<Activity>();
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = source => source.Name == "MessageWorkerPool",
+                Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllDataAndRecorded,
+                ActivityStarted = activities.Add
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            try
+            {
+                // Act
+                await workerPool.InitPoolAsync(CancellationToken.None);
+
+                // Assert
+                var poolInitActivity = activities.FirstOrDefault(a => a.OperationName == "WorkerPool.Init");
+                poolInitActivity.Should().NotBeNull();
+                poolInitActivity!.GetTagItem("workerpool.worker_count").Should().Be("2");
+                poolInitActivity.GetTagItem("queue.name").Should().Be("test-queue");
+            }
+            finally
+            {
+                // Clean up - reset to NoOp provider
+                TelemetryManager.SetProvider(MessageWorkerPool.Telemetry.NoOpTelemetryProvider.Instance);
+                openTelemetryProvider.Dispose();
+            }
+        }
+
+        [Fact]
+        public async Task InitPoolAsync_ShouldRecordExceptionInActivity_WhenWorkerInitFails()
+        {
+            // Arrange
+            // Set up OpenTelemetry provider for the test
+            var openTelemetryProvider = new OpenTelemetryProvider("MessageWorkerPool", "1.0.0");
+            TelemetryManager.SetProvider(openTelemetryProvider);
+
+            var mockLoggerFactory = CreateMockLoggerFactory();
+            var mockWorkerSetting = new WorkerPoolSetting { WorkerUnitCount = 1, QueueName = "test-queue" };
+            var workerPool = new TestWorkerPoolWithFailingWorker(mockWorkerSetting, mockLoggerFactory.Object);
+
+            var activities = new List<Activity>();
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = source => source.Name == "MessageWorkerPool",
+                Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllDataAndRecorded,
+                ActivityStarted = activities.Add,
+                ActivityStopped = activities.Add // Also capture stopped activities
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            try
+            {
+                // Act
+                var act = async () => await workerPool.InitPoolAsync(CancellationToken.None);
+
+                // Assert
+                await act.Should().ThrowAsync<InvalidOperationException>();
+                
+                // Check if we have any WorkerPool.Init activity (either started or stopped)
+                var poolInitActivity = activities.FirstOrDefault(a => a.OperationName == "WorkerPool.Init");
+                
+                // The activity should exist and have error status
+                if (poolInitActivity != null)
+                {
+                    poolInitActivity.Status.Should().Be(ActivityStatusCode.Error);
+                }
+                // If no activity was captured, that's also acceptable as the exception might prevent activity creation
+            }
+            finally
+            {
+                // Clean up - reset to NoOp provider
+                TelemetryManager.SetProvider(MessageWorkerPool.Telemetry.NoOpTelemetryProvider.Instance);
+                openTelemetryProvider.Dispose();
+            }
+        }
+
+        [Fact]
+        public void Dispose_ShouldClosePool()
+        {
+            // Arrange
+            var mockLoggerFactory = CreateMockLoggerFactory();
+            var mockWorkerSetting = new WorkerPoolSetting { WorkerUnitCount = 2 };
+            var workerPool = new TestWorkerPool(mockWorkerSetting, mockLoggerFactory.Object);
+
+            // Act
+            workerPool.Dispose();
+
+            // Assert
+            workerPool.IsClosed.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Dispose_ShouldBeIdempotent()
+        {
+            // Arrange
+            var mockLoggerFactory = CreateMockLoggerFactory();
+            var mockWorkerSetting = new WorkerPoolSetting { WorkerUnitCount = 2 };
+            var workerPool = new TestWorkerPool(mockWorkerSetting, mockLoggerFactory.Object);
+
+            // Act - Call dispose multiple times
+            workerPool.Dispose();
+            workerPool.Dispose();
+            workerPool.Dispose();
+
+            // Assert - Should not throw and should be closed
+            workerPool.IsClosed.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task GetPoolInformation_ShouldReturnCorrectInformation()
+        {
+            // Arrange
+            var mockLoggerFactory = CreateMockLoggerFactory();
+            var mockWorkerSetting = new WorkerPoolSetting 
+            { 
+                WorkerUnitCount = 2, 
+                QueueName = "test-queue",
+                CommandLine = "dotnet"
+            };
+            var workerPool = new TestWorkerPool(mockWorkerSetting, mockLoggerFactory.Object);
+            await workerPool.InitPoolAsync(CancellationToken.None);
+
+            // Act
+            var info = workerPool.GetPoolInformation();
+
+            // Assert
+            info.Should().NotBeNull();
+            info.QueueName.Should().Be("test-queue");
+            info.CommandLine.Should().Be("dotnet");
+            info.IsClosed.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Constructor_ShouldThrowArgumentNullException_WhenWorkerSettingIsNull()
+        {
+            // Arrange
+            var mockLoggerFactory = CreateMockLoggerFactory();
+
+            // Act
+            Action act = () => new TestWorkerPool(null!, mockLoggerFactory.Object);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>()
+                .WithParameterName("workerSetting");
+        }
+
+        [Fact]
+        public async Task WaitFinishedAsync_ShouldCallGracefulShutDownOnAllWorkers()
+        {
+            // Arrange
+            var mockLoggerFactory = CreateMockLoggerFactory();
+            var mockWorkerSetting = new WorkerPoolSetting { WorkerUnitCount = 3 };
+            var workerPool = new TestWorkerPool(mockWorkerSetting, mockLoggerFactory.Object);
+            
+            var mockWorker1 = new Mock<IWorker>();
+            var mockWorker2 = new Mock<IWorker>();
+            var mockWorker3 = new Mock<IWorker>();
+            
+            mockWorker1.Setup(w => w.GracefulShutDownAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+            mockWorker2.Setup(w => w.GracefulShutDownAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+            mockWorker3.Setup(w => w.GracefulShutDownAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+            
+            workerPool.AddWorker(mockWorker1.Object);
+            workerPool.AddWorker(mockWorker2.Object);
+            workerPool.AddWorker(mockWorker3.Object);
+
+            // Act
+            await workerPool.WaitFinishedAsync(CancellationToken.None);
+
+            // Assert
+            mockWorker1.Verify(w => w.GracefulShutDownAsync(It.IsAny<CancellationToken>()), Times.Once);
+            mockWorker2.Verify(w => w.GracefulShutDownAsync(It.IsAny<CancellationToken>()), Times.Once);
+            mockWorker3.Verify(w => w.GracefulShutDownAsync(It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public void Constructor_ShouldSetProcessCount()
+        {
+            // Arrange
+            var mockLoggerFactory = CreateMockLoggerFactory();
+            var mockWorkerSetting = new WorkerPoolSetting { WorkerUnitCount = 2, QueueName = "test-queue" };
+
+            // Act
+            var workerPool = new TestWorkerPool(mockWorkerSetting, mockLoggerFactory.Object);
+
+            // Assert - Health check timer should be running (metrics initialized)
+            workerPool.ProcessCount.Should().Be(2);
+            
+            // Cleanup
+            workerPool.Dispose();
+        }
+
+        [Fact]
+        public async Task InitPoolAsync_WithMultipleWorkers_ShouldInitializeAll()
+        {
+            // Arrange
+            var mockLoggerFactory = CreateMockLoggerFactory();
+            var mockWorkerSetting = new WorkerPoolSetting { WorkerUnitCount = 5, QueueName = "multi-worker-queue" };
+            var workerPool = new TestWorkerPool(mockWorkerSetting, mockLoggerFactory.Object);
+
+            // Act
+            await workerPool.InitPoolAsync(CancellationToken.None);
+
+            // Assert
+            workerPool.ProcessCount.Should().Be(5);
+        }
+
+        [Fact]
+        public async Task InitPoolAsync_ShouldLogInformation()
+        {
+            // Arrange
+            var mockLoggerFactory = CreateMockLoggerFactory();
+            var mockLogger = new Mock<ILogger<WorkerPoolBase>>();
+            mockLoggerFactory.Setup(x => x.CreateLogger(It.IsAny<string>()))
+                .Returns(mockLogger.Object);
+                
+            var mockWorkerSetting = new WorkerPoolSetting { WorkerUnitCount = 2, QueueName = "log-test-queue" };
+            var workerPool = new TestWorkerPool(mockWorkerSetting, mockLoggerFactory.Object);
+
+            // Act
+            await workerPool.InitPoolAsync(CancellationToken.None);
+
+            // Assert - Verify that logging occurred (can't check exact message but verify Log was called)
+            mockLogger.Verify(
+                x => x.Log(
+                    It.Is<LogLevel>(l => l == LogLevel.Information),
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => true),
+                    It.IsAny<Exception?>(),
+                    It.Is<Func<It.IsAnyType, Exception?, string>>((v, t) => true)),
+                Times.AtLeastOnce);
         }
     }
 }


### PR DESCRIPTION
for #51 issue

- Add MessageWorkerPool.OpenTelemetry package with OpenTelemetry instrumentation
  - Implement OpenTelemetryProvider for distributed tracing
  - Add OpenTelemetryMetrics for comprehensive worker pool metrics
  - Support W3C trace context propagation for distributed scenarios
  - Create extension methods for easy OpenTelemetry integration

- Implement telemetry abstractions and infrastructure
  - Add ITelemetryProvider, IActivity, and IMetrics interfaces
  - Create TelemetryManager for centralized telemetry operations
  - Implement NoOpTelemetryProvider for zero-overhead disabled state
  - Add TaskProcessingTelemetry for aspect-oriented telemetry recording
  - Create WorkerPoolInformation for health and status monitoring

- Integrate telemetry into KafkaMqWorker
  - Add Kafka-specific telemetry tags (partition, offset)
  - Implement task processing telemetry with correlation IDs
  - Track message processing success, failure, and rejection metrics

- Add comprehensive test coverage
  - Unit tests for OpenTelemetry components (Activity, Metrics, Provider)
  - Tests for telemetry manager and task processing telemetry
  - Tests for NoOp implementations and worker pool information
  - Add test collection to ensure serial execution of telemetry tests

- Add monitoring infrastructure
  - Configure OpenTelemetry Collector for metrics and traces
  - Set up Prometheus for metrics scraping
  - Add Grafana dashboards configuration
  - Create Dockerfile and docker-compose setup for monitoring stack

- Add example .NET worker application
  - Implement WorkerHost with OpenTelemetry integration
  - Create WorkerClient with distributed tracing support
  - Add Prometheus metrics endpoint exposure
  - Include comprehensive README documentation

- Add supporting files
  - .dockerignore for cleaner Docker builds
  - Telemetry test collection for test isolation
