### PR TITLE
Feature/otel custom instance 

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,12 +241,6 @@ public class Program
 
         var app = builder.Build();
 
-        // Map Prometheus metrics endpoint
-        app.MapPrometheusScrapingEndpoint();
-
-        // Configure URL for metrics endpoint
-        app.Urls.Add("http://*:9464");
-
         await app.RunAsync();
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,39 +37,13 @@ services:
     #build: ./examples_worker/rust
     #stop_grace_period: 120s
     env_file: ./env/.env
-    ports:
-      - "9464-9474:9464"
+    # ports:
+    #   - "9464-9474:9464"
     depends_on:
       - publisher
       - otel-collector
     networks:
       - net-mq
-  # sqlserver:
-  #   image: dog830228/silo-db:1.1
-  #   hostname: sqlsever
-  #   ports:
-  #     - "1433:1433"
-  #   restart: always
-  #   networks:
-  #     - net-mq
-  #   environment:
-  #     ACCEPT_EULA: 'Y'
-  #     SA_PASSWORD: 'test.123'
-  #     MSSQL_PID: 'Standard'
-  # siloweb:
-  #   #build: ./MQDashBoard/Silo/
-  #   image: dog830228/silo-server:1.1
-  #   ports:
-  #     - "8899:8899"
-  #   expose:
-  #     - "8899"
-  #   restart: always
-  #   environment:
-  #     DBConnection: 'Data Source=sqlserver;Initial Catalog=orleans;User ID=sa;Password=test.123;'
-  #   networks:
-  #     - net-mq
-  #   depends_on:
-  #     - sqlserver
 
   # OpenTelemetry Monitoring Stack
   prometheus:
@@ -110,7 +84,6 @@ services:
     ports:
       - "4317:4317"     # OTLP gRPC receiver
       - "4318:4318"     # OTLP HTTP receiver
-      - "8888:8888"     # Prometheus metrics
       - "8889:8889"     # Prometheus exporter metrics
     depends_on:
       - prometheus

--- a/env/.env
+++ b/env/.env
@@ -8,5 +8,4 @@ OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 OTEL_SERVICE_NAME=MessageWorkerPool
 OTEL_SERVICE_VERSION=1.0.0
 OTEL_RESOURCE_ATTRIBUTES=service.namespace=messageworkerpool,deployment.environment=docker-compose
-PROMETHEUS_ENDPOINT=http://otel-collector:8888/metrics
 JAEGER_ENDPOINT=http://jaeger:14268/api/traces

--- a/env/.local_env
+++ b/env/.local_env
@@ -5,5 +5,4 @@ OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 OTEL_SERVICE_NAME=MessageWorkerPool
 OTEL_SERVICE_VERSION=1.0.0
 OTEL_RESOURCE_ATTRIBUTES=service.namespace=messageworkerpool,deployment.environment=docker-compose
-PROMETHEUS_ENDPOINT=http://otel-collector:8888/metrics
 JAEGER_ENDPOINT=http://jaeger:14268/api/traces

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -14,18 +14,18 @@ scrape_configs:
 
   # MessageWorkerPool application metrics - Multi-worker support
   # Docker Compose creates network aliases that resolve to all container IPs
-  - job_name: 'messageworkerpool'
-    dns_sd_configs:
-      - names:
-          - 'workersample'
-        type: 'A'
-        port: 9464
-        refresh_interval: 15s
-    scrape_interval: 10s
-    metrics_path: /metrics
-    honor_timestamps: false
-    scrape_protocols:
-      - PrometheusText0.0.4
+  # - job_name: 'messageworkerpool'
+  #   dns_sd_configs:
+  #     - names:
+  #         - 'workersample'
+  #       type: 'A'
+  #       port: 9464
+  #       refresh_interval: 15s
+  #   scrape_interval: 10s
+  #   metrics_path: /metrics
+  #   honor_timestamps: false
+  #   scrape_protocols:
+  #     - PrometheusText0.0.4
     # Relabel to add instance information
     relabel_configs:
       - source_labels: [__address__]

--- a/src/Examples/DotNetWorker/Dockerfile
+++ b/src/Examples/DotNetWorker/Dockerfile
@@ -11,6 +11,6 @@ WORKDIR /app
 COPY --from=build /app .
 
 # Expose metrics port for Prometheus
-EXPOSE 9464
+# EXPOSE 9464
 
 CMD ["dotnet","host/WorkerHost.dll"]

--- a/src/Examples/DotNetWorker/WorkerClient/Program.cs
+++ b/src/Examples/DotNetWorker/WorkerClient/Program.cs
@@ -16,23 +16,26 @@ namespace WorkerClient
         {
             // Initialize OpenTelemetry for the worker client
             var serviceCollection = new ServiceCollection();
-            serviceCollection.AddMessageWorkerPoolOpenTelemetry("MessageWorkerPool.Example.Client", "1.0.0");
 
             var otlpEndpoint = Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT") ?? "http://localhost:4317";
 
-            // Configure OpenTelemetry tracing with OTLP exporter
-            serviceCollection.AddOpenTelemetry()
-                .ConfigureResource(resource => resource
-                    .AddService("MessageWorkerPool.Example.Client", "1.0.0"))
-                .WithTracing(tracing =>
-                {
-                    tracing.AddMessageWorkerPoolInstrumentation("MessageWorkerPool.Example.Client")
-                        .AddOtlpExporter(options =>
-                        {
-                            options.Endpoint = new Uri(otlpEndpoint);
-                            options.ExportProcessorType = ExportProcessorType.Batch;
-                        });
-                });
+            serviceCollection.AddMessageWorkerPoolTelemetry(options =>
+             {
+                 options.ServiceName = "MessageWorkerPool.Example.Client";
+                 options.ServiceVersion = "1.0.0";
+                 options.EnableRuntimeInstrumentation = true;
+                 options.ServiceInstanceId = Environment.GetEnvironmentVariable("OTEL_SERVICE_INSTANCE_ID");
+
+                 // Configure tracing with OTLP exporter
+                 options.ConfigureTracing = tracing =>
+                 {
+                     tracing.AddOtlpExporter(otlpOptions =>
+                     {
+                         otlpOptions.Endpoint = new Uri(otlpEndpoint);
+                         otlpOptions.ExportProcessorType = ExportProcessorType.Batch;
+                     });
+                 };
+             });
 
 
             using var serviceProvider = serviceCollection.BuildServiceProvider();

--- a/src/Examples/DotNetWorker/WorkerHost/Program.cs
+++ b/src/Examples/DotNetWorker/WorkerHost/Program.cs
@@ -36,7 +36,7 @@ namespace WorkerHost
                 options.ServiceName = "MessageWorkerPool.Example.Host";
                 options.ServiceVersion = "1.0.0";
                 options.EnableRuntimeInstrumentation = true;
-
+                options.ServiceInstanceId = Environment.GetEnvironmentVariable("OTEL_SERVICE_INSTANCE_ID");
                 // Configure metrics with OTLP exporter and Prometheus
                 options.ConfigureMetrics = metrics =>
                 {
@@ -83,10 +83,10 @@ namespace WorkerHost
             var app = builder.Build();
 
             // Map Prometheus metrics endpoint
-            app.MapPrometheusScrapingEndpoint();
+            //app.MapPrometheusScrapingEndpoint();
 
             // Configure URLs for metrics endpoint
-            app.Urls.Add("http://*:9464");
+            //app.Urls.Add("http://*:9464");
 
             await app.RunAsync();
         }

--- a/src/MessageWorkerPool.OpenTelemetry/README.md
+++ b/src/MessageWorkerPool.OpenTelemetry/README.md
@@ -21,19 +21,73 @@ dotnet add package MessageWorkerPool.OpenTelemetry
 Add OpenTelemetry to your MessageWorkerPool application:
 
 ```csharp
-using MessageWorkerPool.OpenTelemetry;
+using MessageWorkerPool.OpenTelemetry.Extensions;
 
-// Configure OpenTelemetry in your service
-services.AddOpenTelemetry()
-    .WithMetrics(metrics =>
+builder.Services.AddMessageWorkerPoolTelemetry(options =>
+{
+    options.ServiceName = "MyWorkerService";
+    options.ServiceVersion = "1.0.0";
+
+    // Configure metrics with OTLP exporter
+    options.ConfigureMetrics = metrics =>
     {
-        metrics.AddMessageWorkerPoolMetrics();
-    })
-    .WithTracing(tracing =>
-    {
-        tracing.AddMessageWorkerPoolTracing();
-    });
+        metrics.AddOtlpExporter(otlpOptions =>
+        {
+            otlpOptions.Endpoint = new Uri("http://otel-collector:4317");
+        });
+    };
+});
 ```
+
+### Custom Service Instance ID
+
+By default, OpenTelemetry generates a random UUID for each service instance. You can customize this to use meaningful identifiers like Docker container names or hostnames:
+
+```csharp
+builder.Services.AddMessageWorkerPoolTelemetry(options =>
+{
+    options.ServiceName = "MyWorkerService";
+    options.ServiceVersion = "1.0.0";
+
+    // Option 1: Set custom instance ID directly
+    options.ServiceInstanceId = "worker-container-01";
+
+    // Option 2: Use environment variable (recommended for Docker/Kubernetes)
+    options.ServiceInstanceId = Environment.GetEnvironmentVariable("OTEL_SERVICE_INSTANCE_ID");
+
+    // Option 3: Leave null to auto-detect (priority order):
+    // 1. HOSTNAME environment variable (Docker container name)
+    // 2. COMPUTERNAME environment variable (Windows)
+    // 3. DNS hostname
+    // If all fail, OpenTelemetry SDK generates a UUID
+});
+```
+
+### Docker Container Setup
+
+To use the container hostname as the instance ID in Docker Compose:
+
+```yaml
+services:
+  workersample:
+    build: ./src/Examples/DotNetWorker
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
+      # The container name will be used as instance ID
+      # Or explicitly set it:
+      - OTEL_SERVICE_INSTANCE_ID=${HOSTNAME}
+```
+
+When you scale your service, each container will have a unique instance ID:
+
+```bash
+docker-compose up --scale workersample=3
+```
+
+This will create instances like:
+- `workersample-1` → `instance="workersample-1"`
+- `workersample-2` → `instance="workersample-2"`
+- `workersample-3` → `instance="workersample-3"`
 
 ## Available Metrics
 

--- a/src/tests/MessageWorkerPool.Test/OpenTelemetry/MessageWorkerPoolOpenTelemetryExtensionsTests.cs
+++ b/src/tests/MessageWorkerPool.Test/OpenTelemetry/MessageWorkerPoolOpenTelemetryExtensionsTests.cs
@@ -902,6 +902,200 @@ namespace MessageWorkerPool.Test.OpenTelemetry.Extensions
             // Assert - Should use the custom provider we registered
             envProvider.Should().BeSameAs(mockProvider);
         }
+
+        [Fact]
+        public void AddMessageWorkerPoolTelemetry_ConfigureResource_WithCustomInstanceId_ShouldNotThrow()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var mockProvider = new MockEnvironmentInfoProvider();
+            mockProvider.SetEnvironmentVariable("HOSTNAME", "test-container");
+            mockProvider.SetHostName("test-host.local");
+            services.AddSingleton<IEnvironmentInfoProvider>(mockProvider);
+
+            services.AddMessageWorkerPoolTelemetry(options =>
+            {
+                options.ServiceName = "TestService";
+                options.ServiceVersion = "1.0.0";
+                options.ServiceInstanceId = "custom-instance-123";
+            });
+
+            // Act - Retrieve TracerProvider to force OpenTelemetry to build and execute ConfigureResource
+            Action act = () =>
+            {
+                using var provider = services.BuildServiceProvider();
+                var tracerProvider = provider.GetService<TracerProvider>();
+                // ConfigureResource should have executed during provider initialization
+            };
+
+            // Assert - Verify ConfigureResource executes without throwing
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void AddMessageWorkerPoolTelemetry_ConfigureResource_WithHostnameEnvVar_ShouldNotThrow()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var mockProvider = new MockEnvironmentInfoProvider();
+            mockProvider.SetEnvironmentVariable("HOSTNAME", "test-container-hostname");
+            mockProvider.SetHostName("fallback-host.local");
+            services.AddSingleton<IEnvironmentInfoProvider>(mockProvider);
+
+            services.AddMessageWorkerPoolTelemetry(options =>
+            {
+                options.ServiceName = "TestService";
+                options.ServiceVersion = "1.0.0";
+                // ServiceInstanceId is null, should use HOSTNAME env var
+            });
+
+            // Act - Retrieve TracerProvider to force ConfigureResource execution
+            Action act = () =>
+            {
+                using var provider = services.BuildServiceProvider();
+                var tracerProvider = provider.GetService<TracerProvider>();
+            };
+
+            // Assert - Verify ConfigureResource uses HOSTNAME without throwing
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void AddMessageWorkerPoolTelemetry_ConfigureResource_WithComputerNameEnvVar_ShouldNotThrow()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var mockProvider = new MockEnvironmentInfoProvider();
+            // HOSTNAME is null, COMPUTERNAME should be used
+            mockProvider.SetEnvironmentVariable("COMPUTERNAME", "test-computer-name");
+            mockProvider.SetHostName("fallback-host.local");
+            services.AddSingleton<IEnvironmentInfoProvider>(mockProvider);
+
+            services.AddMessageWorkerPoolTelemetry(options =>
+            {
+                options.ServiceName = "TestService";
+                options.ServiceVersion = "1.0.0";
+                // ServiceInstanceId is null, HOSTNAME is null, should use COMPUTERNAME
+            });
+
+            // Act - Retrieve TracerProvider to force ConfigureResource execution
+            Action act = () =>
+            {
+                using var provider = services.BuildServiceProvider();
+                var tracerProvider = provider.GetService<TracerProvider>();
+            };
+
+            // Assert - Verify ConfigureResource uses COMPUTERNAME without throwing
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void AddMessageWorkerPoolTelemetry_ConfigureResource_WithHostNameFallback_ShouldNotThrow()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var mockProvider = new MockEnvironmentInfoProvider();
+            // All env vars null, should use GetHostName()
+            mockProvider.SetHostName("dns-hostname.local");
+            services.AddSingleton<IEnvironmentInfoProvider>(mockProvider);
+
+            services.AddMessageWorkerPoolTelemetry(options =>
+            {
+                options.ServiceName = "TestService";
+                options.ServiceVersion = "1.0.0";
+                // ServiceInstanceId, HOSTNAME, COMPUTERNAME all null - should use GetHostName()
+            });
+
+            // Act - Retrieve TracerProvider to force ConfigureResource execution
+            Action act = () =>
+            {
+                using var provider = services.BuildServiceProvider();
+                var tracerProvider = provider.GetService<TracerProvider>();
+            };
+
+            // Assert - Verify ConfigureResource uses GetHostName() without throwing
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void AddMessageWorkerPoolTelemetry_ConfigureResource_WithHostnameForContainerId_ShouldNotThrow()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var mockProvider = new MockEnvironmentInfoProvider();
+            mockProvider.SetEnvironmentVariable("HOSTNAME", "container-123");
+            mockProvider.SetHostName("test-host.local");
+            services.AddSingleton<IEnvironmentInfoProvider>(mockProvider);
+
+            services.AddMessageWorkerPoolTelemetry(options =>
+            {
+                options.ServiceName = "TestService";
+                options.ServiceVersion = "1.0.0";
+            });
+
+            // Act - Retrieve TracerProvider to force ConfigureResource execution
+            Action act = () =>
+            {
+                using var provider = services.BuildServiceProvider();
+                var tracerProvider = provider.GetService<TracerProvider>();
+            };
+
+            // Assert - Verify ConfigureResource sets containerId from HOSTNAME without throwing
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void AddMessageWorkerPoolTelemetry_ConfigureResource_WithNullHostnameForContainerId_ShouldNotThrow()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var mockProvider = new MockEnvironmentInfoProvider();
+            // HOSTNAME is null, containerId should be "N/A"
+            mockProvider.SetHostName("test-host.local");
+            services.AddSingleton<IEnvironmentInfoProvider>(mockProvider);
+
+            services.AddMessageWorkerPoolTelemetry(options =>
+            {
+                options.ServiceName = "TestService";
+                options.ServiceVersion = "1.0.0";
+            });
+
+            // Act - Retrieve TracerProvider to force ConfigureResource execution
+            Action act = () =>
+            {
+                using var provider = services.BuildServiceProvider();
+                var tracerProvider = provider.GetService<TracerProvider>();
+            };
+
+            // Assert - Verify ConfigureResource defaults containerId to "N/A" without throwing
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void AddMessageWorkerPoolTelemetry_ConfigureResource_WithHostNameAttribute_ShouldNotThrow()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var mockProvider = new MockEnvironmentInfoProvider();
+            mockProvider.SetHostName("test-hostname.local");
+            services.AddSingleton<IEnvironmentInfoProvider>(mockProvider);
+
+            services.AddMessageWorkerPoolTelemetry(options =>
+            {
+                options.ServiceName = "TestService";
+                options.ServiceVersion = "1.0.0";
+            });
+
+            // Act - Retrieve TracerProvider to force ConfigureResource execution
+            Action act = () =>
+            {
+                using var provider = services.BuildServiceProvider();
+                var tracerProvider = provider.GetService<TracerProvider>();
+            };
+
+            // Assert - Verify ConfigureResource adds host.name attribute without throwing
+            act.Should().NotThrow();
+        }
     }
 }
 


### PR DESCRIPTION
feat(otel): add custom service instance ID support

- Add ServiceInstanceId property to MessageWorkerPoolTelemetryOptions
- Support custom instance ID configuration for OpenTelemetry metrics
- Auto-detect instance ID from environment (HOSTNAME, COMPUTERNAME, DNS)
- Add resource attributes for host.name and container.id
- Update README with usage examples for Docker/Kubernetes scenarios

test(otel): add comprehensive coverage tests for OpenTelemetry extensions

- Add environment variable fallback chain tests (HOSTNAME → COMPUTERNAME → DNS)
- Add resource attributes configuration tests (host.name, container.id)
- Add runtime instrumentation conditional path tests (enabled/disabled)
- Add null configuration handler tests (metrics/tracing/both)
- Add complete configuration scenario tests
- Add MeterProviderBuilder and TracerProviderBuilder tests

This allows users to use meaningful instance identifiers like container
names instead of random UUIDs, making it easier to identify specific
service instances in distributed systems monitoring.

